### PR TITLE
fix(macos): 打包后自动构造 WCDB.framework，修复 dyld 加载失败

### DIFF
--- a/MACOS_PORT_GUIDE.md
+++ b/MACOS_PORT_GUIDE.md
@@ -251,6 +251,33 @@ Electron 打包时通过 `package.json -> build.extraResources` 带入整个 `re
 - 这只是为后续打包接入准备
 - 当前计划不包含执行 Electron 整包构建
 
+### 10.1 WCDB.framework 自动构造（afterPack）
+
+`libwcdb_api.dylib` 编译时硬链接 `@rpath/WCDB.framework/Versions/<ver>/WCDB`，
+但当前 native 产物把 WCDB 主二进制扁平化为 `libWCDB.dylib` 放在
+`resources/macos/`，`extraResources` 复制后落在 `Contents/Resources/resources/macos/`。
+
+dyld 在运行时按 framework 路径找不到主二进制，会抛出：
+
+```
+Library not loaded: @rpath/WCDB.framework/Versions/<ver>/WCDB
+Reason: tried: '<App>/Contents/Frameworks/WCDB.framework/Versions/<ver>/WCDB' (no such file)
+```
+
+GUI 解密入口随之报 `WCDB 初始化异常: Failed to load shared library`，
+App 实际无法工作。
+
+为了让 mac 装包后开箱即用，`scripts/clean-locales.js` 的 `afterPack`
+钩子会调用 `scripts/setup-macos-wcdb-framework.js`，在打包后自动：
+
+1. 从 `Contents/Resources/resources/macos/libWCDB.dylib` 读取 `install_name`，
+   解析出期望的 framework 版本号（如 `2.1.15`），失败则回退 `A`。
+2. 在 `Contents/Frameworks/WCDB.framework/Versions/<ver>/WCDB` 处放置同一个二进制。
+3. 创建 `Versions/Current` → `<ver>` 与 `WCDB` → `Versions/Current/WCDB` 软链。
+4. 对 framework 内主二进制和 framework 目录做 ad-hoc 重签名。
+
+不删除原 `libWCDB.dylib`，保留作为后向兼容来源。
+
 ## 11. 推荐开发流程
 
 ### 11.1 只开发 native

--- a/scripts/clean-locales.js
+++ b/scripts/clean-locales.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { Arch } = require('electron-builder');
+const { setupMacosWcdbFramework } = require('./setup-macos-wcdb-framework');
 
 const IMAGE_NATIVE_PREFIX = 'ciphertalk-image-native-';
 const IMAGE_NATIVE_SUFFIX = '.node';
@@ -120,5 +121,7 @@ exports.default = async function (context) {
             console.log(`已确保 macOS MCP 启动器可执行: ${launcherPath}`);
             break;
         }
+
+        setupMacosWcdbFramework(context);
     }
 };

--- a/scripts/setup-macos-wcdb-framework.js
+++ b/scripts/setup-macos-wcdb-framework.js
@@ -1,0 +1,117 @@
+const fs = require('fs');
+const path = require('path');
+const { execFileSync, spawnSync } = require('child_process');
+
+const FRAMEWORK_NAME = 'WCDB';
+const SOURCE_DYLIB_NAME = 'libWCDB.dylib';
+const FALLBACK_VERSION = 'A';
+
+/**
+ * 从 dylib 的 install_name 解析期望的 framework 版本号。
+ *
+ * libWCDB.dylib 的 install_name 形如：
+ *   @rpath/WCDB.framework/Versions/2.1.15/WCDB
+ *
+ * 解析失败时回退到 macOS framework 默认版本 "A"。
+ */
+function detectFrameworkVersion(dylibPath) {
+    try {
+        const result = spawnSync('otool', ['-D', dylibPath], { encoding: 'utf8' });
+        if (result.status !== 0) return FALLBACK_VERSION;
+        const match = result.stdout.match(/WCDB\.framework\/Versions\/([^/]+)\/WCDB/);
+        if (match && match[1]) return match[1];
+    } catch (error) {
+        // ignore，回退默认值
+    }
+    return FALLBACK_VERSION;
+}
+
+function safeUnlink(targetPath) {
+    try {
+        fs.unlinkSync(targetPath);
+    } catch (error) {
+        if (error && error.code !== 'ENOENT') throw error;
+    }
+}
+
+/**
+ * 在 mac App 包内构造 WCDB.framework 目录结构。
+ *
+ * 这个修复存在的原因：
+ *
+ *   libwcdb_api.dylib 编译时硬链接 @rpath/WCDB.framework/Versions/<ver>/WCDB，
+ *   但 native 构建产物把 WCDB 主二进制扁平化为 libWCDB.dylib 放在
+ *   resources/macos/，extraResources 复制后落在 Contents/Resources/resources/macos/。
+ *
+ *   dyld 在运行时按 framework 路径找不到主二进制，会抛出：
+ *     Library not loaded: @rpath/WCDB.framework/Versions/<ver>/WCDB
+ *     Reason: tried: '<App>/Contents/Frameworks/WCDB.framework/Versions/<ver>/WCDB' (no such file)
+ *
+ *   导致 GUI 解密入口报 "WCDB 初始化异常: Failed to load shared library"，
+ *   App 实际无法工作。
+ *
+ * 修复办法：
+ *
+ *   把 Contents/Resources/resources/macos/libWCDB.dylib 按标准 framework 结构
+ *   布到 Contents/Frameworks/WCDB.framework/，并 ad-hoc 重签名。
+ *
+ *   不删除原 libWCDB.dylib（保留作为后向兼容来源 / 后备）。
+ */
+function setupMacosWcdbFramework(context) {
+    if (context.electronPlatformName !== 'darwin') return;
+
+    const productName = context.packager?.appInfo?.productFilename || 'CipherTalk';
+    const appBundle = path.join(context.appOutDir, `${productName}.app`);
+    if (!fs.existsSync(appBundle)) {
+        console.warn(`[macos-wcdb-framework] App bundle 不存在，跳过: ${appBundle}`);
+        return;
+    }
+
+    const sourceDylib = path.join(
+        appBundle, 'Contents', 'Resources', 'resources', 'macos', SOURCE_DYLIB_NAME
+    );
+    if (!fs.existsSync(sourceDylib)) {
+        console.warn(`[macos-wcdb-framework] 源 dylib 不存在，跳过: ${sourceDylib}`);
+        return;
+    }
+
+    const version = detectFrameworkVersion(sourceDylib);
+    const frameworkDir = path.join(
+        appBundle, 'Contents', 'Frameworks', `${FRAMEWORK_NAME}.framework`
+    );
+    const versionedDir = path.join(frameworkDir, 'Versions', version);
+    const versionedBinary = path.join(versionedDir, FRAMEWORK_NAME);
+    const currentSymlink = path.join(frameworkDir, 'Versions', 'Current');
+    const topSymlink = path.join(frameworkDir, FRAMEWORK_NAME);
+
+    console.log(`[macos-wcdb-framework] 构建 ${FRAMEWORK_NAME}.framework (version=${version})`);
+
+    // 1. 目录结构
+    fs.mkdirSync(versionedDir, { recursive: true });
+
+    // 2. 复制主二进制
+    fs.copyFileSync(sourceDylib, versionedBinary);
+    fs.chmodSync(versionedBinary, 0o755);
+
+    // 3. Versions/Current → <version>
+    safeUnlink(currentSymlink);
+    fs.symlinkSync(version, currentSymlink);
+
+    // 4. WCDB → Versions/Current/WCDB
+    safeUnlink(topSymlink);
+    fs.symlinkSync(path.join('Versions', 'Current', FRAMEWORK_NAME), topSymlink);
+
+    // 5. ad-hoc 重签名（修改了 framework 内容，原签名失效）
+    try {
+        execFileSync('codesign', ['--force', '--sign', '-', versionedBinary], { stdio: 'inherit' });
+        execFileSync('codesign', ['--force', '--sign', '-', frameworkDir], { stdio: 'inherit' });
+        console.log(`[macos-wcdb-framework] 已 ad-hoc 重签名`);
+    } catch (error) {
+        // 不阻断打包，但要让构建日志清楚提示
+        console.warn(`[macos-wcdb-framework] codesign 失败（继续）: ${String(error)}`);
+    }
+
+    console.log(`[macos-wcdb-framework] 完成: ${frameworkDir}`);
+}
+
+module.exports = { setupMacosWcdbFramework };


### PR DESCRIPTION
libwcdb_api.dylib 编译时硬链接 @rpath/WCDB.framework/Versions/<ver>/WCDB， 但 native 产物把 WCDB 主二进制扁平化为 libWCDB.dylib 放在 resources/macos/， extraResources 复制后落在 Contents/Resources/resources/macos/。dyld 在运行时 按 framework 路径找不到主二进制，导致 mac 装包后 GUI 解密入口报：

    WCDB 初始化异常: Failed to load shared library
    Library not loaded: @rpath/WCDB.framework/Versions/2.1.15/WCDB
    Reason: tried: '<App>/Contents/Frameworks/WCDB.framework/Versions/2.1.15/WCDB' (no such file)

App 实际无法工作。

新增 scripts/setup-macos-wcdb-framework.js，由 clean-locales.js 在 afterPack 钩子里调用，打包后自动：

1. 从 libWCDB.dylib 的 install_name 解析期望的 framework 版本号（解析失败回退 "A"）
2. 在 Contents/Frameworks/WCDB.framework/Versions/<ver>/WCDB 处放置同一个二进制
3. 创建 Versions/Current 与顶层 WCDB 软链
4. 对 framework 内主二进制和 framework 目录做 ad-hoc 重签名

不删除原 libWCDB.dylib，保留作为后向兼容来源。

MACOS_PORT_GUIDE.md 第 10 节补充该机制说明。