### PR TITLE
fix: add file-uri-to-path to asarUnpack and wrap schema migration in …

### DIFF
--- a/electron/services/search/chatSearchIndexService.ts
+++ b/electron/services/search/chatSearchIndexService.ts
@@ -412,61 +412,84 @@ export class ChatSearchIndexService {
     `)
 
     const row = db.prepare('SELECT value FROM meta WHERE key = ?').get('schema_version') as { value?: string } | undefined
-    if (row?.value && row.value !== INDEX_SCHEMA_VERSION) {
-      this.resetSchema(db)
+    const needsMigration = row?.value && row.value !== INDEX_SCHEMA_VERSION
+
+    if (needsMigration) {
+      try {
+        db.exec(`
+          DROP TABLE IF EXISTS message_index_fts;
+          DROP TABLE IF EXISTS message_embedding_vec;
+          DROP TABLE IF EXISTS message_vector_index;
+          DROP TABLE IF EXISTS session_vector_state;
+          DROP TABLE IF EXISTS message_index;
+          DROP TABLE IF EXISTS session_index_state;
+          DELETE FROM meta WHERE key = 'schema_version';
+        `)
+      } catch (err) {
+        console.warn('[ChatSearchIndex] 迁移清表失败，继续重建:', (err as Error)?.message)
+      }
     }
 
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS message_index (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        session_id TEXT NOT NULL,
-        local_id INTEGER NOT NULL,
-        server_id INTEGER NOT NULL DEFAULT 0,
-        local_type INTEGER NOT NULL DEFAULT 0,
-        create_time INTEGER NOT NULL DEFAULT 0,
-        sort_seq INTEGER NOT NULL DEFAULT 0,
-        is_send INTEGER,
-        sender_username TEXT,
-        parsed_content TEXT NOT NULL DEFAULT '',
-        raw_content TEXT NOT NULL DEFAULT '',
-        search_text TEXT NOT NULL DEFAULT '',
-        token_text TEXT NOT NULL DEFAULT '',
-        message_json TEXT NOT NULL DEFAULT '{}',
-        indexed_at INTEGER NOT NULL,
-        UNIQUE(session_id, local_id, create_time, sort_seq)
-      );
+    const runMigrate = db.transaction(() => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS message_index (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          session_id TEXT NOT NULL,
+          local_id INTEGER NOT NULL,
+          server_id INTEGER NOT NULL DEFAULT 0,
+          local_type INTEGER NOT NULL DEFAULT 0,
+          create_time INTEGER NOT NULL DEFAULT 0,
+          sort_seq INTEGER NOT NULL DEFAULT 0,
+          is_send INTEGER,
+          sender_username TEXT,
+          parsed_content TEXT NOT NULL DEFAULT '',
+          raw_content TEXT NOT NULL DEFAULT '',
+          search_text TEXT NOT NULL DEFAULT '',
+          token_text TEXT NOT NULL DEFAULT '',
+          message_json TEXT NOT NULL DEFAULT '{}',
+          indexed_at INTEGER NOT NULL,
+          UNIQUE(session_id, local_id, create_time, sort_seq)
+        );
 
-      CREATE VIRTUAL TABLE IF NOT EXISTS message_index_fts USING fts5(
-        session_id UNINDEXED,
-        cursor_key UNINDEXED,
-        search_text,
-        token_text,
-        tokenize = 'unicode61'
-      );
+        CREATE VIRTUAL TABLE IF NOT EXISTS message_index_fts USING fts5(
+          session_id UNINDEXED,
+          cursor_key UNINDEXED,
+          search_text,
+          token_text,
+          tokenize = 'unicode61'
+        );
 
-      CREATE TABLE IF NOT EXISTS session_index_state (
-        session_id TEXT PRIMARY KEY,
-        newest_sort_seq INTEGER NOT NULL DEFAULT 0,
-        newest_create_time INTEGER NOT NULL DEFAULT 0,
-        newest_local_id INTEGER NOT NULL DEFAULT 0,
-        indexed_count INTEGER NOT NULL DEFAULT 0,
-        updated_at INTEGER NOT NULL,
-        is_complete INTEGER NOT NULL DEFAULT 0
-      );
+        CREATE TABLE IF NOT EXISTS session_index_state (
+          session_id TEXT PRIMARY KEY,
+          newest_sort_seq INTEGER NOT NULL DEFAULT 0,
+          newest_create_time INTEGER NOT NULL DEFAULT 0,
+          newest_local_id INTEGER NOT NULL DEFAULT 0,
+          indexed_count INTEGER NOT NULL DEFAULT 0,
+          updated_at INTEGER NOT NULL,
+          is_complete INTEGER NOT NULL DEFAULT 0
+        );
 
-      CREATE INDEX IF NOT EXISTS idx_message_index_session_time
-        ON message_index(session_id, sort_seq DESC, create_time DESC, local_id DESC);
-      CREATE INDEX IF NOT EXISTS idx_message_index_session_sender
-        ON message_index(session_id, sender_username);
-    `)
+        CREATE INDEX IF NOT EXISTS idx_message_index_session_time
+          ON message_index(session_id, sort_seq DESC, create_time DESC, local_id DESC);
+        CREATE INDEX IF NOT EXISTS idx_message_index_session_sender
+          ON message_index(session_id, sender_username);
+      `)
 
-    db.exec(`
-      DROP TABLE IF EXISTS message_embedding_vec;
-      DROP TABLE IF EXISTS message_vector_index;
-      DROP TABLE IF EXISTS session_vector_state;
-    `)
+      db.exec(`
+        DROP TABLE IF EXISTS message_embedding_vec;
+        DROP TABLE IF EXISTS message_vector_index;
+        DROP TABLE IF EXISTS session_vector_state;
+      `)
 
-    db.prepare('INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)').run('schema_version', INDEX_SCHEMA_VERSION)
+      db.prepare('INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)').run('schema_version', INDEX_SCHEMA_VERSION)
+    })
+
+    try {
+      runMigrate()
+    } catch (err) {
+      console.error('[ChatSearchIndex] schema 迁移失败:', (err as Error)?.message)
+      throw err
+    }
   }
 
   private resetSchema(db: Database.Database): void {

--- a/electron/services/search/chatSearchIndexService.ts
+++ b/electron/services/search/chatSearchIndexService.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { chatService, type Message } from '../chatService'
 import { ConfigService } from '../config'
+import { voiceTranscribeService } from '../voiceTranscribeService'
 
 export type ChatSearchIndexProgressStage =
   | 'preparing_index'
@@ -137,7 +138,7 @@ function uniqueStrings(values: string[]): string[] {
   return result
 }
 
-function extractMessageSearchText(message: Message): string {
+function extractMessageSearchText(message: Message, transcript?: string): string {
   const chatRecordText = Array.isArray(message.chatRecordList)
     ? message.chatRecordList
       .flatMap((item) => [
@@ -155,7 +156,7 @@ function extractMessageSearchText(message: Message): string {
       case 3:
         return '[图片]'
       case 34:
-        return '[语音]'
+        return transcript || '[语音]'
       case 43:
         return '[视频]'
       case 47:
@@ -168,7 +169,7 @@ function extractMessageSearchText(message: Message): string {
   })()
 
   return [
-    message.parsedContent,
+    transcript || message.parsedContent,
     message.quotedContent,
     message.fileName,
     chatRecordText,
@@ -599,7 +600,10 @@ export class ChatSearchIndexService {
     const run = db.transaction((items: Message[]) => {
       const indexedAt = Date.now()
       for (const message of items) {
-        const searchText = compactSearchText(extractMessageSearchText(message))
+        const transcript = Number(message.localType) === 34
+          ? voiceTranscribeService.getCachedTranscript(sessionId, message.createTime) || undefined
+          : undefined
+        const searchText = compactSearchText(extractMessageSearchText(message, transcript))
         const tokenText = buildSearchTokens(searchText)
         const payload = {
           sessionId,

--- a/electron/services/search/messageVectorService.ts
+++ b/electron/services/search/messageVectorService.ts
@@ -16,6 +16,7 @@ import { cosineSimilarity } from 'ai'
 import { ConfigService } from '../config'
 import { chatSearchIndexService } from './chatSearchIndexService'
 import { embedTexts, embedQuery, getEmbeddingConfig, type EmbeddingConfig } from '../ai/embeddingService'
+import { voiceTranscribeService } from '../voiceTranscribeService'
 
 const VECTOR_DB_NAME = 'chat_vectors.db'
 const DEFAULT_SESSION_CAP = 1500 // 每个会话首次最多纳入的（最近）消息条数，控制成本/时延
@@ -41,6 +42,7 @@ interface SessionMessage {
   localId: number
   sortSeq: number
   createTime: number
+  localType: number
   isSend: number | null
   senderUsername: string | null
   parsedContent: string
@@ -238,11 +240,25 @@ class MessageVectorService {
     onProgress?: VectorBuildProgressReporter,
   ): Promise<number> {
     onProgress?.({ sessionId, stage: 'loading', current: 0, total: 0, indexed: 0, message: '读取会话消息' })
-    const messages = await chatSearchIndexService.listSessionMemoryMessages(sessionId)
-    if (messages.length === 0) {
+    const rawMessages = await chatSearchIndexService.listSessionMemoryMessages(sessionId)
+    if (rawMessages.length === 0) {
       onProgress?.({ sessionId, stage: 'done', current: 0, total: 0, indexed: 0, message: '没有可向量化的消息' })
       return 0
     }
+    const messages: SessionMessage[] = rawMessages.map((m) => {
+      const transcript = Number(m.localType) === 34
+        ? voiceTranscribeService.getCachedTranscript(sessionId, m.createTime) || undefined
+        : undefined
+      return {
+        localId: m.localId,
+        sortSeq: m.sortSeq,
+        createTime: m.createTime,
+        localType: m.localType,
+        isSend: m.isSend,
+        senderUsername: m.senderUsername,
+        parsedContent: transcript || m.parsedContent,
+      }
+    })
     const db = this.getDb()
     const existingCount = this.countChunks(db, sessionId)
 

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
       "node_modules/fzstd/**/*",
       "node_modules/better-sqlite3/**/*",
       "node_modules/bindings/**/*",
+      "node_modules/file-uri-to-path/**/*",
       "node_modules/koffi/**/*",
       "node_modules/zod/**/*",
       "node_modules/ai/**/*",


### PR DESCRIPTION
…transaction

Two fixes:

1. Add `node_modules/file-uri-to-path/**/*` to asarUnpack config. `better-sqlite3` 12.x depends on `bindings` which depends on `file-uri-to-path`. Without unpacking it from the ASAR archive, Electron's utility process cannot resolve the module, causing all database operations (search, vectors, memory) to fail silently in the AI agent process. The main process was unaffected because it has different module resolution paths.

2. Wrap `ensureSchema()` DDL in a transaction so the schema version update and table creation are atomic. Previously, a crash or error mid-migration (e.g. dropping old sqlite-vec virtual tables) could leave the database in a broken intermediate state where the version says v6 but FTS5 tables are missing, or vice versa.