### PR TITLE
fix(mac): 修复 macOS ARM 平台多项错误

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -279,7 +279,12 @@ if (gotSingleInstanceLock) {
     startNightlyMemoryConsolidation(ctx)
 
     app.on('activate', () => {
-      if (BrowserWindow.getAllWindows().length === 0) {
+      const mainWindow = ctx.getMainWindow()
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        if (mainWindow.isMinimized()) mainWindow.restore()
+        mainWindow.show()
+        mainWindow.focus()
+      } else {
         ctx.getWindowManager().createMainWindow()
         ctx.getWindowManager().createTray()
       }

--- a/electron/services/ai/embeddingService.ts
+++ b/electron/services/ai/embeddingService.ts
@@ -101,14 +101,32 @@ export function embedQuery(
   return promise
 }
 
-/** 测试嵌入配置：成功则回传实际维度。 */
-export async function testEmbeddingConfig(cfg: EmbeddingConfig): Promise<{ success: boolean; dimension?: number; error?: string }> {
+/** 测试嵌入配置：成功则回传实际维度。优先按用户设定维度测试，不匹配则回退到默认维度重试。 */
+export async function testEmbeddingConfig(cfg: EmbeddingConfig): Promise<{ success: boolean; dimension?: number; error?: string; dimensionMismatch?: string }> {
   try {
-    const vector = await embedQuery('密语语义检索连接测试', cfg)
+    const userDimension = cfg.dimension && cfg.dimension > 0 ? cfg.dimension : 0
+    let vector: number[]
+    if (userDimension > 0) {
+      try {
+        vector = await embedQuery('密语语义检索连接测试', cfg)
+      } catch {
+        vector = await embedQuery('密语语义检索连接测试', { ...cfg, dimension: 0 })
+      }
+    } else {
+      vector = await embedQuery('密语语义检索连接测试', cfg)
+    }
     if (!Array.isArray(vector) || vector.length === 0) {
       return { success: false, error: '嵌入返回为空' }
     }
-    return { success: true, dimension: vector.length }
+    const actualDim = vector.length
+    if (userDimension > 0 && actualDim !== userDimension) {
+      return {
+        success: true,
+        dimension: actualDim,
+        dimensionMismatch: `连接成功，回退到模型默认维度 ${actualDim}`
+      }
+    }
+    return { success: true, dimension: actualDim }
   } catch (e) {
     return { success: false, error: e instanceof Error ? e.message : String(e) }
   }

--- a/electron/services/imageDecryptService.ts
+++ b/electron/services/imageDecryptService.ts
@@ -1152,6 +1152,22 @@ export class ImageDecryptService {
       hardlinkPaths.push(accountPath)
     }
 
+    // Mac: 动态扫描 xwechat_files 下各子目录的 hardlink 路径
+    if (process.platform === 'darwin' && wxid) {
+      const home = (await import('os')).homedir()
+      const xwechatRoot = join(home, 'Library', 'Containers', 'com.tencent.xinWeChat', 'Data', 'Documents', 'xwechat_files')
+      if (existsSync(xwechatRoot)) {
+        try {
+          for (const entry of readdirSync(xwechatRoot)) {
+            const candidate = join(xwechatRoot, entry, 'db_storage', 'hardlink')
+            if (existsSync(candidate) && !hardlinkPaths.includes(candidate)) {
+              hardlinkPaths.push(candidate)
+            }
+          }
+        } catch { /* ignore */ }
+      }
+    }
+
     if (hardlinkPaths.length === 0) {
       return null
     }

--- a/electron/services/imageKeyService.ts
+++ b/electron/services/imageKeyService.ts
@@ -2,6 +2,9 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as crypto from 'crypto'
 
+// Windows-only module: Mac 使用 wxKeyServiceMac.ts 的 Mach API 替代
+const IS_WIN = process.platform === 'win32'
+
 // Windows API 常量
 const PROCESS_ALL_ACCESS = 0x1F0FFF
 const MEM_COMMIT = 0x1000
@@ -21,6 +24,7 @@ let ReadProcessMemory: any = null
 let MEMORY_BASIC_INFORMATION: any = null
 
 function ensureKernel32(): boolean {
+  if (!IS_WIN) return false
   if (kernel32) return true
   
   try {

--- a/electron/services/nativeImageDecrypt.ts
+++ b/electron/services/nativeImageDecrypt.ts
@@ -77,11 +77,13 @@ function loadAddon(): NativeAddon | null {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const addon = require(candidate) as NativeAddon
       if (addon && typeof addon.decryptDatNative === 'function') {
+        console.log(`[nativeImageDecrypt] 加载成功: ${candidate}`)
         cachedAddon = addon
         return addon
       }
-    } catch {
-      // try next candidate
+      console.warn(`[nativeImageDecrypt] 文件存在但缺少 decryptDatNative 函数: ${candidate}`)
+    } catch (e: any) {
+      console.error(`[nativeImageDecrypt] 加载失败: ${candidate}`, e?.message || e)
     }
   }
 
@@ -143,13 +145,17 @@ export function decryptDatViaNative(
   try {
     const result = addon.decryptDatNative(inputPath, xorKey, aesKey)
     const isWxgf = Boolean(result?.isWxgf ?? result?.is_wxgf)
-    if (!result || !Buffer.isBuffer(result.data)) return null
+    if (!result || !Buffer.isBuffer(result.data)) {
+      console.warn(`[nativeImageDecrypt] 解密返回无效数据: ${inputPath}`)
+      return null
+    }
     const rawExt = typeof result.ext === 'string' && result.ext.trim()
       ? result.ext.trim().toLowerCase()
       : ''
     const ext = rawExt ? (rawExt.startsWith('.') ? rawExt : `.${rawExt}`) : ''
     return { data: result.data, ext, isWxgf }
-  } catch {
+  } catch (e: any) {
+    console.error(`[nativeImageDecrypt] 解密异常: ${inputPath}`, e?.message || e)
     return null
   }
 }

--- a/electron/services/runtimePaths.ts
+++ b/electron/services/runtimePaths.ts
@@ -21,6 +21,9 @@ export function getUserDataPath(): string {
     return app.getPath('userData')
   }
 
+  if (process.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Application Support', 'ciphertalk')
+  }
   const appData = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming')
   return path.join(appData, 'ciphertalk')
 }

--- a/electron/services/videoService.ts
+++ b/electron/services/videoService.ts
@@ -311,6 +311,20 @@ class VideoService {
       join(cachePath, 'databases', wxid, 'hardlink.db')
     ])
 
+    // Mac: 动态扫描 xwechat_files 下各子目录的 hardlink 路径
+    if (process.platform === 'darwin') {
+      const home = require('os').homedir()
+      const xwechatRoot = join(home, 'Library', 'Containers', 'com.tencent.xinWeChat', 'Data', 'Documents', 'xwechat_files')
+      if (existsSync(xwechatRoot)) {
+        try {
+          const entries = readdirSync(xwechatRoot)
+          for (const entry of entries) {
+            possiblePaths.add(join(xwechatRoot, entry, 'db_storage', 'hardlink'))
+          }
+        } catch { /* ignore */ }
+      }
+    }
+
     if (dbPath) {
       const baseCandidates = new Set<string>([
         dbPath,

--- a/electron/services/wcdbCore.ts
+++ b/electron/services/wcdbCore.ts
@@ -70,6 +70,16 @@ export class WcdbCore {
   }
 
   private prepareWindowsDllSearchPath(libraryPath: string): { success: boolean; error?: string } {
+    if (process.platform === 'darwin') {
+      const dylibDir = dirname(libraryPath)
+      const currentDyld = process.env.DYLD_LIBRARY_PATH || ''
+      if (!currentDyld.includes(dylibDir)) {
+        process.env.DYLD_LIBRARY_PATH = dylibDir + (currentDyld ? ':' + currentDyld : '')
+        console.log(`[wcdbCore] 设置 DYLD_LIBRARY_PATH: ${dylibDir}`)
+      }
+      return { success: true }
+    }
+
     if (process.platform !== 'win32') return { success: true }
 
     const wcdbCorePath = this.getWindowsCoreLibraryPath()

--- a/electron/services/wxKeyServiceMac.ts
+++ b/electron/services/wxKeyServiceMac.ts
@@ -164,12 +164,14 @@ export class WxKeyServiceMac {
     try {
       this.koffi = require('koffi')
       const dylibPath = this.getDylibPath()
+      console.log('[WxKeyServiceMac] 加载 dylib:', dylibPath)
       this.lib = this.koffi.load(dylibPath)
       this.GetDbKey = this.lib.func('const char* GetDbKey()')
       this.ListWeChatProcesses = this.lib.func('const char* ListWeChatProcesses()')
       this.initialized = true
       return true
-    } catch {
+    } catch (e: any) {
+      console.error('[WxKeyServiceMac] 初始化失败:', e?.message || e)
       return false
     }
   }
@@ -434,6 +436,14 @@ export class WxKeyServiceMac {
     onProgress?: (message: string) => void
   ): Promise<ImageKeyResult> {
     try {
+      const sipStatus = await this.checkSipStatus()
+      if (sipStatus.enabled) {
+        return {
+          success: false,
+          error: 'SIP (系统完整性保护) 已开启，内存扫描需要关闭 SIP 后重试'
+        }
+      }
+
       onProgress?.('正在查找图片模板文件...')
       let result = await this.findTemplateData(userDir, 32)
       let { ciphertext, xorKey } = result
@@ -861,6 +871,7 @@ export class WxKeyServiceMac {
         this.koffi = require('koffi')
       }
 
+      console.log('[WxKeyServiceMac] 加载 Mach API: /usr/lib/libSystem.B.dylib')
       this.libSystem = this.koffi.load('/usr/lib/libSystem.B.dylib')
       this.machTaskSelf = this.libSystem.func('mach_task_self', 'uint32', [])
       this.taskForPid = this.libSystem.func('task_for_pid', 'int', ['uint32', 'int', this.koffi.out('uint32*')])
@@ -882,8 +893,8 @@ export class WxKeyServiceMac {
       ])
       this.machPortDeallocate = this.libSystem.func('mach_port_deallocate', 'int', ['uint32', 'uint32'])
       return true
-    } catch (e) {
-      console.error('[WxKeyServiceMac] 初始化 Mach API 失败:', e)
+    } catch (e: any) {
+      console.error('[WxKeyServiceMac] 初始化 Mach API 失败:', e?.message || e)
       return false
     }
   }
@@ -932,6 +943,7 @@ export class WxKeyServiceMac {
     const attachKr = this.taskForPid(selfTask, pid, taskBuf)
     const task = taskBuf.readUInt32LE(0)
     if (attachKr !== KERN_SUCCESS || !task) {
+      console.error(`[WxKeyServiceMac] task_for_pid 失败: kr=${attachKr}, task=${task}, pid=${pid}（可能需要关闭 SIP 或授予调试权限）`)
       return null
     }
 

--- a/src/components/settings/tabs/EmbeddingTab.tsx
+++ b/src/components/settings/tabs/EmbeddingTab.tsx
@@ -47,12 +47,11 @@ export default function EmbeddingTab() {
     try {
       const res = await window.electronAPI.embedding.test(cfg)
       if (res.success) {
-        // 不自动回填维度：避免"测试没发 dimensions、实际发了"不一致。仅提示探测到的维度。
         setStatus({
           ok: true,
-          text: cfg.dimension > 0
-            ? `连接成功，按设定维度输出 ${res.dimension}`
-            : `连接成功，模型默认维度 ${res.dimension}（如需固定维度，在上方"向量维度"填写）`,
+          text: res.dimensionMismatch || (cfg.dimension > 0
+            ? `连接成功，探测到模型维度 ${res.dimension}`
+            : `连接成功，模型默认维度 ${res.dimension}（如需固定维度，在上方"向量维度"填写）`),
         })
       } else {
         setStatus({ ok: false, text: res.error || '测试失败' })

--- a/src/pages/chat/ChatPage.tsx
+++ b/src/pages/chat/ChatPage.tsx
@@ -1,4 +1,4 @@
-﻿import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { MessageSquare } from 'lucide-react'
 import { useChatStore, MAX_ACTIVE_MESSAGES } from '../../stores/chatStore'
 import { useUpdateStatusStore } from '../../stores/updateStatusStore'
@@ -253,7 +253,7 @@ function ChatPage(_props: ChatPageProps) {
 
       const saveResult = await window.electronAPI.dialog.saveFile({
         title: '导出语音文件',
-        defaultPath: `${downloadsPath}\\${fileName}`,
+        defaultPath: `${downloadsPath}${window.navigator.platform.toLowerCase().includes('win') ? '\\' : '/'}${fileName}`,
         filters: [{ name: 'WAV 音频', extensions: ['wav'] }]
       })
 

--- a/src/pages/chat/components/messageBubble/TextBubble.tsx
+++ b/src/pages/chat/components/messageBubble/TextBubble.tsx
@@ -267,17 +267,33 @@ function TextBubble({ message, session, isSent, onContextMenu }: TextBubbleProps
           const year = msgDate.getFullYear()
           const month = String(msgDate.getMonth() + 1).padStart(2, '0')
           const dateFolder = `${year}-${month}`
-          const filePath = `${wechatDir}\\${wxid}\\msg\\file\\${dateFolder}\\${fileName}`
+          const isWin = window.navigator.platform.toLowerCase().includes('win')
+          const sep = isWin ? '\\' : '/'
 
-          try {
-            await window.electronAPI.shell.showItemInFolder(filePath)
-          } catch (err) {
-            console.warn('无法定位到具体文件，尝试打开文件夹:', err)
-            const fileDir = `${wechatDir}\\${wxid}\\msg\\file\\${dateFolder}`
-            const result = await window.electronAPI.shell.openPath(fileDir)
-            if (result) {
-              console.warn('无法打开月份文件夹，尝试打开上级目录')
-              await window.electronAPI.shell.openPath(`${wechatDir}\\${wxid}\\msg\\file`)
+          const candidates = [
+            `${wechatDir}${sep}${wxid}${sep}msg${sep}file${sep}${dateFolder}${sep}${fileName}`,
+            `${wechatDir}${sep}${wxid}${sep}FileStorage${sep}File${sep}${dateFolder}${sep}${fileName}`,
+            `${wechatDir}${sep}FileStorage${sep}File${sep}${dateFolder}${sep}${fileName}`,
+          ]
+
+          let opened = false
+          for (const filePath of candidates) {
+            try {
+              await window.electronAPI.shell.showItemInFolder(filePath)
+              opened = true
+              break
+            } catch { /* try next */ }
+          }
+
+          if (!opened) {
+            const fileDir = `${wechatDir}${sep}${wxid}${sep}msg${sep}file${sep}${dateFolder}`
+            try {
+              const result = await window.electronAPI.shell.openPath(fileDir)
+              if (result) {
+                await window.electronAPI.shell.openPath(`${wechatDir}${sep}${wxid}${sep}msg${sep}file`)
+              }
+            } catch {
+              await window.electronAPI.shell.openPath(wechatDir)
             }
           }
         } catch (error) {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -1250,7 +1250,7 @@ export interface ElectronAPI {
   embedding: {
     getConfig: () => Promise<{ success: boolean; config?: EmbeddingConfig; error?: string }>
     setConfig: (patch: Partial<EmbeddingConfig>) => Promise<{ success: boolean; config?: EmbeddingConfig; error?: string }>
-    test: (cfg: EmbeddingConfig) => Promise<{ success: boolean; dimension?: number; error?: string }>
+    test: (cfg: EmbeddingConfig) => Promise<{ success: boolean; dimension?: number; error?: string; dimensionMismatch?: string }>
     sessionStatus: (sessionId: string) => Promise<{ success: boolean; enabled?: boolean; count?: number; store?: EmbeddingVectorStoreInfo; error?: string }>
     buildSession: (sessionId: string) => Promise<{ success: boolean; indexed?: number; error?: string }>
     onBuildProgress: (callback: (progress: EmbeddingBuildProgress) => void) => () => void

--- a/src/utils/windowChrome.ts
+++ b/src/utils/windowChrome.ts
@@ -11,7 +11,16 @@ type WindowControlsOverlayPadding = {
   right: number
 }
 
-const DEFAULT_PLATFORM: WindowPlatform = 'win32'
+function detectPlatform(): WindowPlatform {
+  if (typeof navigator !== 'undefined') {
+    const ua = navigator.platform.toLowerCase()
+    if (ua.includes('mac')) return 'darwin'
+    if (ua.includes('linux')) return 'linux'
+  }
+  return 'win32'
+}
+
+const DEFAULT_PLATFORM: WindowPlatform = detectPlatform()
 const WINDOW_CHROME_HEIGHT = '40px'
 
 const WINDOW_CHROME_METRICS: Record<WindowPlatform, WindowChromeMetrics> = {


### PR DESCRIPTION
## 修复内容

- **向量维度测试失败**：优先按用户设定维度测试，若模型返回维度不匹配，自动回退到模型默认维度并提示"连接成功，回退到模型默认维度 {N}"
- **Mac 原生模块日志**：wxKeyServiceMac 的 dylib 加载、Mach API 初始化、task_for_pid 失败均输出详细错误日志和路径
- **Mac dylib 依赖**：darwin 平台下自动设置 DYLD_LIBRARY_PATH 指向 dylib 所在目录
- **.node 加载日志**：nativeImageDecrypt 加载成功输出路径、加载失败输出路径+错误、解密异常输出输入路径+错误
- **Mac fallback 路径**：darwin 平台 fallback 从 `AppData/Roaming` 修正为 `~/Library/Application Support/ciphertalk`
- **Mac Dock 窗口假死**：`activate` 事件改为直接 show/restore/focus 已有窗口，不再只创建新窗口
- **补充视频 hardlink.db 路径**：动态扫描 `xwechat_files/*` 下各子目录的 `db_storage/hardlink` 路径
- **文件无法打开路径**：修复 `process.platform` 在 renderer 不可用导致路径损坏，尝试多个候选路径（msg/file、FileStorage/File 等）
- **save dialog 路径**：`defaultPath` 改用 `navigator.platform` 判断分隔符
- **imageKeyService 平台守卫**：添加 `IS_WIN` 守卫，非 Windows 平台 `ensureKernel32` 直接返回 false
- **内存扫描 SIP 检查**：`autoGetImageKeyByMemoryScan` 启动前检查 SIP 状态，开启时直接返回错误
- **默认平台检测**：`windowChrome` 通过 `navigator.platform` 动态检测，Mac 上不再闪现 Windows 样式