### PR TITLE
fix: 测试连接对 OpenRouter 真实校验 API Key，避免无效 key 也提示成功

### DIFF
--- a/electron/services/ai/providers/base.ts
+++ b/electron/services/ai/providers/base.ts
@@ -303,7 +303,7 @@ function normalizeBaseURL(baseURL: string): string {
   return String(baseURL || '').trim().replace(/\/+$/, '')
 }
 
-function joinEndpoint(baseURL: string, path: string): string {
+export function joinEndpoint(baseURL: string, path: string): string {
   const normalized = normalizeBaseURL(baseURL)
   return `${normalized}${path.startsWith('/') ? path : `/${path}`}`
 }

--- a/electron/services/ai/providers/catalog.ts
+++ b/electron/services/ai/providers/catalog.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { BaseAIProvider, type ProviderKind } from './base'
+import { BaseAIProvider, joinEndpoint, type ProviderKind } from './base'
 import { getAppPath, getUserDataPath, isElectronPackaged } from '../../runtimePaths'
 
 export type AIProviderProtocol = ProviderKind
@@ -562,6 +562,38 @@ export class CatalogAIProvider extends BaseAIProvider {
     if (!secretId || !secretKey) return undefined
     return { Authorization: `Bearer ${secretId};${secretKey}` }
   }
+
+  private isOpenRouterEndpoint(): boolean {
+    try {
+      return new URL(this.baseURL).hostname.toLowerCase().endsWith('openrouter.ai')
+    } catch {
+      return false
+    }
+  }
+
+  async testConnection(): Promise<{ success: boolean; error?: string; needsProxy?: boolean }> {
+    const result = await super.testConnection()
+    // OpenRouter 的 /models 不鉴权，模型列表拉取成功不代表 key 有效；再打需要鉴权的 /key 端点真实校验
+    if (!result.success || !this.isOpenRouterEndpoint()) return result
+
+    try {
+      const response = await fetch(joinEndpoint(this.baseURL, '/key'), {
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+        signal: AbortSignal.timeout(10000)
+      })
+      if (response.ok) return result
+      const body = await response.text().catch(() => '')
+      return { success: false, error: `API Key 无效（${response.status}）${body ? `: ${truncateKeyCheckBody(body)}` : ''}` }
+    } catch {
+      // /models 已证明网络可达，/key 探测自身异常时不误报失败
+      return result
+    }
+  }
+}
+
+function truncateKeyCheckBody(body: string): string {
+  const trimmed = body.trim()
+  return trimmed.length > 200 ? `${trimmed.slice(0, 200)}…` : trimmed
 }
 
 export async function getModelsDevModels(providerId: string): Promise<string[]> {


### PR DESCRIPTION
Fixes #249

## 问题

「测试连接」只调用 GET `/models`，而 OpenRouter 的该端点不需要鉴权，导致填错 API Key 也会提示"连接测试成功"，用户直到真正聊天才收到误导性的 401 "Missing Authentication header"（详细分析见 #249）。

## 修改

- `electron/services/ai/providers/catalog.ts`：`CatalogAIProvider` 覆写 `testConnection()` —— 原有 `/models` 测试通过且 baseURL 为 `openrouter.ai` 域名时，追加 GET `/key`（OpenRouter 官方 key 校验端点，需鉴权、零成本）；非 2xx 时返回明确的「API Key 无效（状态码）」错误。`/key` 探测自身网络异常时不改变原结果，避免误报。其他服务商行为完全不变。
- `electron/services/ai/providers/base.ts`：导出 `joinEndpoint`（仅加 `export`，无逻辑改动）。

## 验证

- `npx tsc` 通过
- 脚本实例化 `CatalogAIProvider` 实测：错误格式 key / 纯空白 key → `{"success":false,"error":"API Key 无效（401）…"}`；
- curl 实测 OpenRouter：`/models` 无鉴权返回 200（原测试假成功的原因），`/key` 对无效 key 返回 401
- 本地 electron-builder 打包后手工验证：填错 key 点「测试连接」即时报「API Key 无效（401）」，换有效 key 后测试通过、对话正常