### PR TITLE
fix(mcp): exit cleanly when stdio disconnects

### DIFF
--- a/electron/services/mcp/bootstrap.ts
+++ b/electron/services/mcp/bootstrap.ts
@@ -1,23 +1,74 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { createCipherTalkMcpServer } from './server'
 
+const SHUTDOWN_TIMEOUT_MS = 1_000
+const CLOSED_PIPE_ERROR_CODES = new Set(['EPIPE', 'ERR_STREAM_DESTROYED'])
+
 let mcpServer: ReturnType<typeof createCipherTalkMcpServer> | null = null
 let isShuttingDown = false
+let processHandlersInstalled = false
+
+function isClosedPipeError(error: unknown) {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    CLOSED_PIPE_ERROR_CODES.has(String(error.code))
+  )
+}
+
+function writeDiagnostic(message: string) {
+  if (!process.stderr.destroyed) {
+    process.stderr.write(message)
+  }
+}
 
 async function shutdown(code = 0) {
   if (isShuttingDown) return
   isShuttingDown = true
 
+  const forceExitTimer = setTimeout(() => {
+    process.exit(code)
+  }, SHUTDOWN_TIMEOUT_MS)
+  forceExitTimer.unref()
+
   try {
     await mcpServer?.close?.()
   } catch (error) {
-    process.stderr.write(`[CipherTalk MCP] close error: ${String(error)}\n`)
+    if (!isClosedPipeError(error)) {
+      writeDiagnostic(`[CipherTalk MCP] close error: ${String(error)}\n`)
+    }
   } finally {
+    clearTimeout(forceExitTimer)
     process.exit(code)
   }
 }
 
 function installProcessHandlers() {
+  if (processHandlersInstalled) return
+  processHandlersInstalled = true
+
+  const handleOutputError = (error: Error) => {
+    // Once an MCP client's output pipe closes, there is no channel left for a
+    // graceful response. Exiting directly also prevents recursive EPIPE errors.
+    process.exit(isClosedPipeError(error) ? 0 : 1)
+  }
+
+  process.stdin.once('end', () => {
+    void shutdown(0)
+  })
+
+  process.stdin.once('close', () => {
+    void shutdown(0)
+  })
+
+  process.stdin.once('error', () => {
+    void shutdown(1)
+  })
+
+  process.stdout.on('error', handleOutputError)
+  process.stderr.on('error', handleOutputError)
+
   process.on('SIGINT', () => {
     void shutdown(0)
   })
@@ -27,12 +78,15 @@ function installProcessHandlers() {
   })
 
   process.on('uncaughtException', (error) => {
-    process.stderr.write(`[CipherTalk MCP] uncaughtException: ${String(error)}\n`)
+    if (isClosedPipeError(error)) {
+      process.exit(0)
+    }
+    writeDiagnostic(`[CipherTalk MCP] uncaughtException: ${String(error)}\n`)
     void shutdown(1)
   })
 
   process.on('unhandledRejection', (error) => {
-    process.stderr.write(`[CipherTalk MCP] unhandledRejection: ${String(error)}\n`)
+    writeDiagnostic(`[CipherTalk MCP] unhandledRejection: ${String(error)}\n`)
     void shutdown(1)
   })
 }
@@ -44,9 +98,9 @@ export async function bootstrapCipherTalkMcpServer() {
     mcpServer = createCipherTalkMcpServer()
     const transport = new StdioServerTransport()
     await mcpServer.connect(transport)
-    process.stderr.write('[CipherTalk MCP] stdio server started\n')
+    writeDiagnostic('[CipherTalk MCP] stdio server started\n')
   } catch (error) {
-    process.stderr.write(`[CipherTalk MCP] startup failed: ${String(error)}\n`)
+    writeDiagnostic(`[CipherTalk MCP] startup failed: ${String(error)}\n`)
     await shutdown(1)
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "notify:telegram": "node scripts/send-telegram-release.js",
     "mcp": "node scripts/mcp-runner.js",
     "mcp:probe": "node scripts/mcp-probe.js",
+    "test:mcp-lifecycle": "npm run build:mcp && node scripts/test-mcp-stdio-lifecycle.cjs",
     "cli": "npm --prefix CipherTalk-CLI run dev --",
     "cli:install": "npm --prefix CipherTalk-CLI install",
     "cli:typecheck": "npm --prefix CipherTalk-CLI run typecheck",

--- a/scripts/test-mcp-stdio-lifecycle.cjs
+++ b/scripts/test-mcp-stdio-lifecycle.cjs
@@ -1,0 +1,140 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const { spawn } = require('node:child_process')
+const test = require('node:test')
+const electronBinary = require('electron')
+
+const rootDir = path.resolve(__dirname, '..')
+const mcpEntry = path.join(rootDir, 'dist-electron', 'mcp.js')
+const readyLine = '[CipherTalk MCP] stdio server started'
+
+function startMcpServer() {
+  assert.ok(
+    fs.existsSync(mcpEntry),
+    'dist-electron/mcp.js is missing; run npm run build:mcp before this test'
+  )
+
+  return spawn(electronBinary, [mcpEntry], {
+    cwd: rootDir,
+    env: {
+      ...process.env,
+      ELECTRON_RUN_AS_NODE: '1',
+      CIPHERTALK_MCP_LAUNCHER: 'stdio-lifecycle-test'
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true
+  })
+}
+
+function stopMcpServer(child) {
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill('SIGKILL')
+  }
+}
+
+function waitForReady(child, timeoutMs = 5_000) {
+  return new Promise((resolve, reject) => {
+    let stderr = ''
+
+    const cleanup = () => {
+      clearTimeout(timer)
+      child.stderr.off('data', onData)
+      child.off('exit', onExit)
+      child.off('error', onError)
+    }
+    const onData = (chunk) => {
+      stderr += chunk.toString()
+      if (stderr.includes(readyLine)) {
+        cleanup()
+        resolve()
+      }
+    }
+    const onExit = (code, signal) => {
+      cleanup()
+      reject(
+        new Error(
+          `MCP exited before becoming ready (code=${code}, signal=${signal}): ${stderr}`
+        )
+      )
+    }
+    const onError = (error) => {
+      cleanup()
+      reject(error)
+    }
+    const timer = setTimeout(() => {
+      cleanup()
+      reject(new Error(`MCP did not become ready within ${timeoutMs}ms: ${stderr}`))
+    }, timeoutMs)
+
+    child.stderr.on('data', onData)
+    child.once('exit', onExit)
+    child.once('error', onError)
+  })
+}
+
+function waitForExit(child, timeoutMs = 3_000) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode })
+  }
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer)
+      child.off('exit', onExit)
+      child.off('error', onError)
+    }
+    const onExit = (code, signal) => {
+      cleanup()
+      resolve({ code, signal })
+    }
+    const onError = (error) => {
+      cleanup()
+      reject(error)
+    }
+    const timer = setTimeout(() => {
+      cleanup()
+      reject(new Error(`MCP did not exit within ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    child.once('exit', onExit)
+    child.once('error', onError)
+  })
+}
+
+function initializeRequest() {
+  return `${JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'stdio-lifecycle-test', version: '1.0.0' }
+    }
+  })}\n`
+}
+
+test('MCP exits when its stdin client disconnects', { timeout: 10_000 }, async (t) => {
+  const child = startMcpServer()
+  t.after(() => stopMcpServer(child))
+
+  await waitForReady(child)
+  child.stdin.end()
+
+  assert.deepEqual(await waitForExit(child), { code: 0, signal: null })
+})
+
+test('MCP exits without an exception loop when output pipes close', { timeout: 10_000 }, async (t) => {
+  const child = startMcpServer()
+  t.after(() => stopMcpServer(child))
+
+  await waitForReady(child)
+  child.stdout.destroy()
+  child.stderr.destroy()
+  child.stdin.write(initializeRequest())
+
+  assert.deepEqual(await waitForExit(child), { code: 0, signal: null })
+})


### PR DESCRIPTION
## Summary

- exit the MCP stdio process when its input client disconnects
- treat closed output pipes as clean shutdowns to prevent recursive `EPIPE` / `uncaughtException` loops
- cap graceful shutdown at one second and add regression coverage for stdin EOF and broken output pipes

## Reproduction

With the current bootstrap, disconnecting the MCP client's output pipe and then sending an initialize request leaves the process spinning at about 100% of one CPU core. In a local packaged-app reproduction, CPU time increased by 1.997 seconds over 2.000 seconds (99.9%).

The process can also remain orphaned after stdin disconnects because the server does not currently observe EOF.

## Tests

- `npm run test:mcp-lifecycle`
- `npx tsc --noEmit`
- `npm test` *(not available: package.json has no `test` script)*