### PR TITLE
fix: 统一 Agent 输入栏图标按钮尺寸

### DIFF
--- a/src/pages/agent/AgentMentions.tsx
+++ b/src/pages/agent/AgentMentions.tsx
@@ -556,6 +556,7 @@ export function MentionTriggerButton({ showGroupSeparator = false }: { showGroup
   return (
     <HeroButton
       aria-label="提及联系人或群"
+      className="size-8 p-0"
       isIconOnly
       onPress={() => {
         const v = textInput.value

--- a/src/pages/agent/AgentPromptToolbar.tsx
+++ b/src/pages/agent/AgentPromptToolbar.tsx
@@ -89,7 +89,7 @@ export function PromptPresetButton({ showGroupSeparator = false }: { showGroupSe
 
   return (
     <Dropdown isOpen={isOpen} onOpenChange={setIsOpen}>
-      <HeroButton aria-label="打开提示词列表" isIconOnly size="sm" variant="tertiary" onPress={() => setIsOpen(true)}>
+      <HeroButton aria-label="打开提示词列表" className="size-8 p-0" isIconOnly size="sm" variant="tertiary" onPress={() => setIsOpen(true)}>
         {showGroupSeparator && <ButtonGroup.Separator />}
         <Sparkles className="size-3.5" />
       </HeroButton>
@@ -183,7 +183,7 @@ export function SlashCommandButton({
 
   return (
     <Dropdown isOpen={isOpen} onOpenChange={handleOpenChange}>
-      <HeroButton aria-label="打开斜杠命令" isIconOnly size="sm" variant="tertiary" onPress={openSlashMenu}>
+      <HeroButton aria-label="打开斜杠命令" className="size-8 p-0" isIconOnly size="sm" variant="tertiary" onPress={openSlashMenu}>
         {showGroupSeparator && <ButtonGroup.Separator />}
         <span aria-hidden className="text-sm font-semibold leading-none">/</span>
       </HeroButton>


### PR DESCRIPTION
## 改动
为 Agent 输入栏工具栏的三个图标按钮补充 `className="size-8 p-0"`：

- `AgentMentions.tsx` 的 `MentionTriggerButton`（提及联系人或群）
- `AgentPromptToolbar.tsx` 的 `PromptPresetButton`（提示词列表）
- `AgentPromptToolbar.tsx` 的 `SlashCommandButton`（斜杠命令）

## 复现步骤
1. 打开 **CT-Agent（Agent）** 对话界面，聚焦到输入框上方的工具栏。
2. 按 `Cmd + +`（或 `Cmd + =`）放大页面缩放比例，多按几次放大更明显。
3. 观察工具栏左侧的「+」按钮，与它旁边的三个图标按钮（提及 / 提示词 / 斜杠命令）。
4. 放大后可以看到：**这三个图标按钮明显比「+」按钮更大**，尺寸与对齐不一致。

## 原因
这三个 `HeroButton` 之前没有显式约束为固定的方形尺寸，大小由内部图标撑开，尽管在默认缩放比例下显示正常，但是增大缩放比例就会出现它们三个比工具栏里其他的「+」按钮更大的问题。

补充 `className="size-8 p-0"` 后，它们被统一约束为 32×32 方形、零内边距，与工具栏其它图标按钮保持一致。

## 验证
- 打开 Agent 输入栏，确认提及、提示词、斜杠命令三个图标按钮尺寸一致、与「+」按钮对齐整齐；放大/缩小缩放比例后三者仍保持一致。