### PR TITLE
修复时间段内无消息时正确展示错误提示

### DIFF
--- a/electron/services/exportService.ts
+++ b/electron/services/exportService.ts
@@ -868,6 +868,10 @@ class ExportService {
           }
       }
 
+      if (allMessages.length === 0) {
+        return { success: false, error: '没有消息可导出' }
+      }
+
       // 按时间排序
       allMessages.sort((a, b) => a.createTime - b.createTime)
 
@@ -1594,6 +1598,10 @@ class ExportService {
           }
       }
 
+      if (allMessages.length === 0) {
+        return { success: false, error: '没有消息可导出' }
+      }
+
       // 按时间排序
       allMessages.sort((a, b) => a.createTime - b.createTime)
 
@@ -2214,6 +2222,10 @@ class ExportService {
           }
       }
 
+      if (allMessages.length === 0) {
+        return { success: false, error: '没有消息可导出' }
+      }
+
       // 按时间排序
       allMessages.sort((a, b) => a.createTime - b.createTime)
 
@@ -2382,6 +2394,7 @@ class ExportService {
   ): Promise<{ success: boolean; successCount: number; failCount: number; error?: string; outputPaths?: string[] }> {
     let successCount = 0
     let failCount = 0
+    const failErrors: string[] = []
     const outputPathSet = new Set<string>()
 
     expWatchdogStart()
@@ -2490,6 +2503,7 @@ class ExportService {
           outputPathSet.add(outputPath)
         } else {
           failCount++
+          if (result.error) failErrors.push(result.error)
           console.error(`导出 ${sessionId} 失败:`, result.error)
         }
 
@@ -2513,7 +2527,10 @@ class ExportService {
         detail: '导出完成'
       })
 
-      return { success: true, successCount, failCount, outputPaths: Array.from(outputPathSet) }
+      const aggregatedError = failErrors.length > 0
+        ? [...new Set(failErrors)].join('；')
+        : undefined
+      return { success: successCount > 0, successCount, failCount, error: aggregatedError, outputPaths: Array.from(outputPathSet) }
     } catch (e) {
       return { success: false, successCount, failCount, error: String(e), outputPaths: Array.from(outputPathSet) }
     } finally {

--- a/src/pages/export/components/ExportResultModal.tsx
+++ b/src/pages/export/components/ExportResultModal.tsx
@@ -11,6 +11,8 @@ interface ExportResultModalProps {
 }
 
 export default function ExportResultModal({ result, unitLabel, onOpenFolder, onClose }: ExportResultModalProps) {
+  const hasSuccess = (result.successCount ?? 0) > 0
+
   return (
     <Modal isOpen onOpenChange={(open) => { if (!open) onClose() }}>
       <Modal.Backdrop>
@@ -18,25 +20,24 @@ export default function ExportResultModal({ result, unitLabel, onOpenFolder, onC
           <Modal.Dialog>
             <Modal.CloseTrigger />
             <Modal.Header>
-              <Modal.Icon className={result.success ? 'bg-success-soft text-success-soft-foreground' : 'bg-danger-soft text-danger-soft-foreground'}>
-                {result.success ? <CircleCheck className="size-5" /> : <CircleXmark className="size-5" />}
+              <Modal.Icon className={hasSuccess ? 'bg-success-soft text-success-soft-foreground' : 'bg-danger-soft text-danger-soft-foreground'}>
+                {hasSuccess ? <CircleCheck className="size-5" /> : <CircleXmark className="size-5" />}
               </Modal.Icon>
-              <Modal.Heading>{result.success ? '导出完成' : '导出失败'}</Modal.Heading>
+              <Modal.Heading>{hasSuccess ? '导出完成' : '导出失败'}</Modal.Heading>
             </Modal.Header>
             <Modal.Body>
-              {result.success ? (
+              {result.successCount !== undefined && (
                 <Typography type="body-sm" className="text-muted">
-                  {result.successCount !== undefined
-                    ? `成功导出 ${result.successCount} ${unitLabel}`
-                    : '导出成功'}
+                  成功导出 {result.successCount} {unitLabel}
                   {result.failCount ? `，${result.failCount} 个失败` : ''}
                 </Typography>
-              ) : (
-                <Typography type="body-sm" className="text-danger">{result.error}</Typography>
+              )}
+              {result.error && (
+                <Typography type="body-sm" className="text-danger mt-2">{result.error}</Typography>
               )}
             </Modal.Body>
             <Modal.Footer>
-              {result.success && (
+              {hasSuccess && (
                 <Button variant="tertiary" onPress={onOpenFolder}>
                   <ArrowUpRightFromSquare width={16} height={16} />
                   打开文件夹


### PR DESCRIPTION
- ChatLab/JSON/SQL 格式新增空消息检查，统一返回'没有消息可导出'
- exportSessions 收集单个会话失败错误，去重汇聚后返回 error 字段
- success 语义修正：全部失败返回 false，部分成功保留 true
- ExportResultModal 重构：始终展示统计和错误详情
- 标题/图标基于 successCount 而非模糊的 success 布尔值

hi，很厉害啊，一直在更新功能
问题描述：
在此之前，即使某段时间内消息为空，会直接显示导出成功，成功0失败1。不显示任何错误信息，大大影响用户体验。