### PR TITLE
优化 Agent 思考链折叠时机与消息字号，支持 ⌘, 打开设置

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -248,7 +248,6 @@ if (gotSingleInstanceLock) {
     }
 
     ctx.getWindowManager().setDockIcon()
-    ctx.getWindowManager().setupApplicationMenu()
 
     if (!configService.get('mcpProxyToken')) {
       markStartupMilestone('startup:mcp-token-create-start')
@@ -314,6 +313,10 @@ if (gotSingleInstanceLock) {
         ctx.getWindowManager().openPetWindow()
       }
     }
+
+    // 菜单必须等窗口编排结束再注册：⌘, 会走 focusMainWindow() 建窗口，
+    // 提前注册会和上面的 createMainWindow() 撞成两个主窗口，还会覆盖 Context 里的窗口/服务引用。
+    ctx.getWindowManager().setupApplicationMenu()
 
     // 启动后台同步放在窗口编排之后，避免启动连接数据库时抢占磁盘 IO。
     markStartupMilestone('startup:background-sync-start')

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -248,6 +248,7 @@ if (gotSingleInstanceLock) {
     }
 
     ctx.getWindowManager().setDockIcon()
+    ctx.getWindowManager().setupApplicationMenu()
 
     if (!configService.get('mcpProxyToken')) {
       markStartupMilestone('startup:mcp-token-create-start')

--- a/electron/main/context.ts
+++ b/electron/main/context.ts
@@ -44,6 +44,8 @@ export interface WindowManager {
   createTray(): Tray | null
   destroyTray(): void
   focusMainWindow(route?: string): BrowserWindow
+  /** 注册应用菜单；macOS 上把 ⌘, 绑到设置页 */
+  setupApplicationMenu(): void
   setDockIcon(): void
   openChatWindow(): BrowserWindow
   openMomentsWindow(filterUsername?: string): BrowserWindow

--- a/electron/main/windows/windowManager.ts
+++ b/electron/main/windows/windowManager.ts
@@ -6,7 +6,8 @@ import {
   nativeTheme,
   screen,
   Tray,
-  type BrowserWindowConstructorOptions
+  type BrowserWindowConstructorOptions,
+  type MenuItemConstructorOptions
 } from 'electron'
 import { createHash } from 'crypto'
 import { join } from 'path'
@@ -849,6 +850,55 @@ export function createWindowManager(ctx: MainProcessContext): WindowManager {
         tray.destroy()
         ctx.setTray(null)
       }
+    },
+
+    setupApplicationMenu() {
+      const openSettings = () => {
+        manager.focusMainWindow('/settings')
+      }
+      const settingsItem: MenuItemConstructorOptions = {
+        label: '设置…',
+        accelerator: 'CommandOrControl+,',
+        click: openSettings,
+      }
+
+      const template: MenuItemConstructorOptions[] = []
+      if (process.platform === 'darwin') {
+        template.push({
+          label: app.name,
+          submenu: [
+            { role: 'about' },
+            { type: 'separator' },
+            settingsItem,
+            { type: 'separator' },
+            { role: 'services' },
+            { type: 'separator' },
+            { role: 'hide' },
+            { role: 'hideOthers' },
+            { role: 'unhide' },
+            { type: 'separator' },
+            { role: 'quit' },
+          ],
+        })
+        template.push({ role: 'fileMenu' })
+      } else {
+        template.push({
+          label: '文件',
+          submenu: [
+            settingsItem,
+            { type: 'separator' },
+            { role: 'quit' },
+          ],
+        })
+      }
+
+      template.push(
+        { role: 'editMenu' },
+        { role: 'viewMenu' },
+        { role: 'windowMenu' },
+      )
+
+      Menu.setApplicationMenu(Menu.buildFromTemplate(template))
     },
 
     focusMainWindow(route?: string) {

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -74,7 +74,8 @@ export const MessageContent = ({
 }: MessageContentProps) => (
   <div
     className={cn(
-      "is-user:dark flex w-fit max-w-full min-w-0 flex-col gap-2 overflow-hidden text-sm",
+      // 聊天正文用 18px：长文阅读更舒适，且只动消息区，不靠全局 Cmd+/- 撑开整页 UI
+      "is-user:dark flex w-fit max-w-full min-w-0 flex-col gap-2 overflow-hidden text-[18px] leading-7",
       "group-[.is-user]:ml-auto group-[.is-user]:rounded-(--agent-radius,12px) group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
       "group-[.is-assistant]:text-foreground",
       className

--- a/src/pages/agent/AgentMessageItem.tsx
+++ b/src/pages/agent/AgentMessageItem.tsx
@@ -133,6 +133,15 @@ function AgentMessageItemImpl({
   const orderedSegments = buildRenderSegments(message.parts)
   const chainSegmentCount = orderedSegments.reduce((count, segment) => count + (segment.kind === 'chain' ? 1 : 0), 0)
   const persistedSingleChainElapsedMs = chainSegmentCount === 1 ? persistedProcessingElapsedMs : undefined
+  // 折叠时机只认两件事：后方出现了非空正文 text，或后方还有新的过程块。
+  // source-url / source-document / data-canvas / data-compaction 等 part 只是工具事件、不含正文，
+  // 不能让它们把仍在进行的思考链提前收起。
+  let lastChainSegmentIndex = -1
+  let lastBodyTextSegmentIndex = -1
+  orderedSegments.forEach((segment, index) => {
+    if (segment.kind === 'chain') lastChainSegmentIndex = index
+    else if (segment.part.type === 'text' && segment.part.text.trim()) lastBodyTextSegmentIndex = index
+  })
   // 一条消息里同一画布可能有多次 data-canvas（多轮编辑），只保留最后一条引用行
   const lastCanvasRefIndexById = new Map<string, number>()
   message.parts.forEach((part, index) => {
@@ -285,9 +294,12 @@ function AgentMessageItemImpl({
           {orderedSegments.map((segment, segmentIndex) => {
             const isLastSegment = segmentIndex === orderedSegments.length - 1
             if (segment.kind === 'chain') {
-              // 过程块仅在仍是消息末尾时保持展开；一旦开始输出正文（或后续新过程），立即收起为「已处理」。
+              // 过程块仅在它还是最后一个过程块、且正文尚未开始时保持展开；
+              // 一旦开始输出正文（或后续又起了新过程），立即收起为「已处理」。
               // 不要用 busy 贯穿整轮：否则思考结束后、正文流式输出期间思考链仍展开，和正文样式混淆。
-              const segmentActive = chainActive && isLastSegment
+              const segmentActive = chainActive
+                && segmentIndex === lastChainSegmentIndex
+                && lastBodyTextSegmentIndex < segmentIndex
               return (
                 <div className="space-y-2" key={`chain-${segment.items[0]?.index ?? 0}`}>
                   {renderChainSegment(segment.items, segmentActive)}

--- a/src/pages/agent/AgentMessageItem.tsx
+++ b/src/pages/agent/AgentMessageItem.tsx
@@ -132,10 +132,6 @@ function AgentMessageItemImpl({
     : []
   const orderedSegments = buildRenderSegments(message.parts)
   const chainSegmentCount = orderedSegments.reduce((count, segment) => count + (segment.kind === 'chain' ? 1 : 0), 0)
-  const lastChainSegmentIndex = orderedSegments.reduce(
-    (lastIndex, segment, index) => segment.kind === 'chain' ? index : lastIndex,
-    -1,
-  )
   const persistedSingleChainElapsedMs = chainSegmentCount === 1 ? persistedProcessingElapsedMs : undefined
   // 一条消息里同一画布可能有多次 data-canvas（多轮编辑），只保留最后一条引用行
   const lastCanvasRefIndexById = new Map<string, number>()
@@ -212,7 +208,7 @@ function AgentMessageItemImpl({
           const reasoningActive = isReasoningStreaming && index === message.parts.length - 1
           return (
             <MessageResponse
-              className="text-foreground text-sm"
+              className="border-border/60 border-l-2 pl-3 text-[15px] leading-6 text-muted-foreground"
               isStreaming={reasoningActive}
               key={`chain-${index}`}
               showStreamingIndicator={false}
@@ -289,8 +285,9 @@ function AgentMessageItemImpl({
           {orderedSegments.map((segment, segmentIndex) => {
             const isLastSegment = segmentIndex === orderedSegments.length - 1
             if (segment.kind === 'chain') {
-              // 每个过程区块独立计时；新过程出现后，前一个区块立即冻结为“已处理”。
-              const segmentActive = chainActive && segmentIndex === lastChainSegmentIndex
+              // 过程块仅在仍是消息末尾时保持展开；一旦开始输出正文（或后续新过程），立即收起为「已处理」。
+              // 不要用 busy 贯穿整轮：否则思考结束后、正文流式输出期间思考链仍展开，和正文样式混淆。
+              const segmentActive = chainActive && isLastSegment
               return (
                 <div className="space-y-2" key={`chain-${segment.items[0]?.index ?? 0}`}>
                   {renderChainSegment(segment.items, segmentActive)}


### PR DESCRIPTION
## Summary
- Agent 一开始输出正文时就自动收起思考链，不用等整段回复结束
- 消息正文调到 18px，思考内容略小并弱化样式，方便区分
- macOS / Windows 支持 `⌘,` / `Ctrl+,` 打开设置

## Test plan
- [ ] 开一轮带思考的对话：思考时应展开，正文一出来思考链应收起
- [ ] 对比正文与思考内容的字号/颜色是否容易区分
- [ ] 按 `⌘,`（或 `Ctrl+,`）能进设置页
- [ ] 「已处理 Xs」那条灰色圆角条尺寸看起来和原来差不多