### PR TITLE
fix(export): 导出图片为空 / 进程崩溃 / 明文图片被解坏

### DIFF
--- a/electron/services/closedPipeStdin.ts
+++ b/electron/services/closedPipeStdin.ts
@@ -1,0 +1,53 @@
+import type { Writable } from 'stream'
+
+/** 子进程提前退出后，向已关闭的 stdin 写入时的常见错误码（含 Windows EOF）。 */
+export const CLOSED_PIPE_ERROR_CODES = new Set([
+  'EPIPE',
+  'ERR_STREAM_DESTROYED',
+  'EOF',
+])
+
+export function isClosedPipeError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code
+  return typeof code === 'string' && CLOSED_PIPE_ERROR_CODES.has(code)
+}
+
+/**
+ * 监听 stdin error：closed-pipe 类错误静默忽略，其余交给 onUnexpected。
+ * 未挂此监听时，Node 会把 stdin 'error' 当成未处理异常拖垮进程。
+ */
+export function attachClosedPipeStdinGuard(
+  stdin: Writable,
+  onUnexpected?: (err: NodeJS.ErrnoException) => void
+): void {
+  stdin.on('error', (err: NodeJS.ErrnoException) => {
+    if (isClosedPipeError(err)) return
+    onUnexpected?.(err)
+  })
+}
+
+/**
+ * 向 stdin 写入完整 buffer，在 write 回调里 end。
+ * closed-pipe 错误吞掉；其它写入错误回调 onUnexpected。
+ */
+export function writeAndEndStdin(
+  stdin: Writable,
+  data: Buffer,
+  onUnexpected?: (err: Error) => void
+): void {
+  try {
+    stdin.write(data, (writeErr: Error | null | undefined) => {
+      if (writeErr) {
+        if (!isClosedPipeError(writeErr)) onUnexpected?.(writeErr)
+        return
+      }
+      try {
+        stdin.end()
+      } catch {
+        /* ignore */
+      }
+    })
+  } catch (e) {
+    if (!isClosedPipeError(e)) onUnexpected?.(e as Error)
+  }
+}

--- a/electron/services/datDecryptCore.ts
+++ b/electron/services/datDecryptCore.ts
@@ -6,6 +6,7 @@
  */
 import { readFileSync, existsSync } from 'fs'
 import crypto from 'crypto'
+import { stripTrailingNulBytes } from './imageComplete'
 
 export type DatDecryptOutcome = {
   data: Buffer
@@ -76,7 +77,8 @@ export function decryptDatV3(inputPath: string, xorKey: number): Buffer {
   // 旧版微信偶发把明文 JPEG/PNG 直接落成 .dat（无 V4 头）。此时再 XOR 会毁掉文件头，
   // 表现为「图片不完整」且 headHex 像 8cab8c93…（即 ffd8ffe0 XOR 0x73）。
   if (detectImageExtension(data)) {
-    return data
+    // 明文 .dat 常带尾部 0x00 填充，裁掉以免下游 IEND/EOI 校验误判不完整
+    return stripTrailingNulBytes(data)
   }
   const out = Buffer.alloc(data.length)
   for (let i = 0; i < data.length; i += 1) {

--- a/electron/services/datDecryptCore.ts
+++ b/electron/services/datDecryptCore.ts
@@ -73,6 +73,11 @@ function strictRemovePadding(data: Buffer): Buffer {
 
 export function decryptDatV3(inputPath: string, xorKey: number): Buffer {
   const data = readFileSync(inputPath)
+  // 旧版微信偶发把明文 JPEG/PNG 直接落成 .dat（无 V4 头）。此时再 XOR 会毁掉文件头，
+  // 表现为「图片不完整」且 headHex 像 8cab8c93…（即 ffd8ffe0 XOR 0x73）。
+  if (detectImageExtension(data)) {
+    return data
+  }
   const out = Buffer.alloc(data.length)
   for (let i = 0; i < data.length; i += 1) {
     out[i] = data[i] ^ xorKey

--- a/electron/services/exportService.ts
+++ b/electron/services/exportService.ts
@@ -13,6 +13,7 @@ import { wcdbService } from './wcdbService'
 import { findMessageDbPaths, findDbByName, getDbStoragePath } from './dbStoragePaths'
 import { snsService, isVideoUrl, type SnsPost, type SnsShareInfo } from './snsService'
 import { parseQuoteMessage } from './chat/contentParsers'
+import { localPathFromFileUrl } from './fileUrlPath'
 
 // ChatLab 0.0.2 格式类型定义
 export interface ChatLabHeader {
@@ -2866,11 +2867,8 @@ class ExportService {
                   if (__dtImg > 1000) expLog(`慢图片 ${imageMd5 || imageDatName}: ${__dtImg}ms (success=${cacheResult.success})`)
 
                   if (cacheResult.success && cacheResult.localPath) {
-                    // localPath 是 file:///path?v=xxx 格式，转为本地路径
-                    let filePath = cacheResult.localPath
-                      .replace(/\?v=\d+$/, '')
-                      .replace(/^file:\/\/\//i, '')
-                    filePath = decodeURIComponent(filePath)
+                    // localPath 是 file:///path?v=xxx；必须用 fileURLToPath，勿 strip file:///（会丢掉 macOS 路径前导 /）
+                    const filePath = localPathFromFileUrl(cacheResult.localPath)
 
                     if (fs.existsSync(filePath)) {
                       const ext = path.extname(filePath) || '.jpg'
@@ -2903,7 +2901,7 @@ class ExportService {
                   const __dtVid = Date.now() - __tVid
                   if (__dtVid > 1000) expLog(`慢视频 ${videoMd5}: ${__dtVid}ms (exists=${videoInfo.exists})`)
                   if (videoInfo.exists && videoInfo.videoUrl) {
-                    const videoPath = videoInfo.videoUrl.replace(/^file:\/\/\//i, '').replace(/\//g, path.sep)
+                    const videoPath = localPathFromFileUrl(videoInfo.videoUrl)
                     if (fs.existsSync(videoPath)) {
                       const fileName = `${createTime}_${videoMd5}.mp4`
                       const df = this.dateFolder(createTime)

--- a/electron/services/fileUrlPath.ts
+++ b/electron/services/fileUrlPath.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from 'url'
+
+/**
+ * 将 file:// URL（可带 ?v=mtime 缓存戳）转为本地绝对路径。
+ * 不要用 replace(/^file:\/\/\//) —— 在 macOS/Linux 上会吃掉路径开头的 `/`。
+ */
+export function localPathFromFileUrl(urlOrPath: string): string {
+  const trimmed = String(urlOrPath || '').trim()
+  if (!trimmed) return trimmed
+  if (!/^file:/i.test(trimmed)) return trimmed
+  const withoutQuery = trimmed.replace(/\?v=\d+$/, '')
+  return fileURLToPath(withoutQuery)
+}

--- a/electron/services/imageComplete.ts
+++ b/electron/services/imageComplete.ts
@@ -1,0 +1,53 @@
+/**
+ * 图片 buffer 完整性：尾部零填充裁剪 + EOI/IEND 校验。
+ * 供 imageDecryptService 与回归脚本共用。
+ */
+
+export function stripTrailingNulBytes(data: Buffer): Buffer {
+  if (!data || data.length === 0) return data
+  let end = data.length
+  while (end > 0 && data[end - 1] === 0x00) end -= 1
+  return end === data.length ? data : data.subarray(0, end)
+}
+
+/**
+ * 验证图片数据是否完整。
+ * 会先去掉尾部 0x00 填充（旧微信明文 .dat 常见），再查结束标记。
+ */
+export function verifyImageComplete(data: Buffer, ext: string): boolean {
+  if (!data || data.length < 100) return false
+
+  const trimmed = stripTrailingNulBytes(data)
+  if (trimmed.length < 100) return false
+
+  const lowerExt = ext.toLowerCase()
+
+  if (lowerExt === '.jpg' || lowerExt === '.jpeg') {
+    const searchLen = Math.min(trimmed.length, 64)
+    for (let i = trimmed.length - 2; i >= trimmed.length - searchLen; i--) {
+      if (trimmed[i] === 0xFF && trimmed[i + 1] === 0xD9) {
+        return true
+      }
+    }
+    // Motion Photo：JPEG 后跟 MP4，EOI 可能在后 1/4 区间
+    const quarterStart = Math.floor(trimmed.length * 3 / 4)
+    for (let i = quarterStart; i < trimmed.length - 1; i++) {
+      if (trimmed[i] === 0xFF && trimmed[i + 1] === 0xD9) {
+        return true
+      }
+    }
+    return false
+  }
+
+  if (lowerExt === '.png') {
+    if (trimmed.length < 12) return false
+    const tail = trimmed.subarray(trimmed.length - 12)
+    return tail[4] === 0x49 && tail[5] === 0x45 && tail[6] === 0x4E && tail[7] === 0x44
+  }
+
+  if (lowerExt === '.gif') {
+    return trimmed[trimmed.length - 1] === 0x3B
+  }
+
+  return trimmed.length > 100
+}

--- a/electron/services/imageDecryptService.ts
+++ b/electron/services/imageDecryptService.ts
@@ -20,6 +20,8 @@ import {
   looksLikeNativeImagePayload as looksLikeNativeImagePayloadCore
 } from './datDecryptCore'
 import { imageDecryptWorkerPool } from './imageDecryptWorkerPool'
+import { attachClosedPipeStdinGuard, writeAndEndStdin } from './closedPipeStdin'
+import { stripTrailingNulBytes, verifyImageComplete as verifyImageCompleteCore } from './imageComplete'
 
 const execFileAsync = promisify(execFile)
 
@@ -729,6 +731,9 @@ export class ImageDecryptService {
 
       const finalExt = ext || '.jpg'
       finalExtForLog = finalExt
+
+      // 旧明文 .dat 常带尾部 0x00 填充；裁掉后再做完整性校验与落盘
+      decrypted = stripTrailingNulBytes(decrypted)
 
       // 图片完整性校验：检测解密后的数据是否有完整的结束标记
       const isImageComplete = this.verifyImageComplete(decrypted, finalExt)
@@ -2125,11 +2130,15 @@ export class ImageDecryptService {
       }
 
       if (ext.endsWith('.png')) {
-        // PNG: 末尾应有 IEND chunk
-        const buf = Buffer.alloc(12)
-        fs.readSync(fd, buf, 0, 12, fileSize - 12)
+        // PNG: 末尾应有 IEND；允许尾部 0x00 填充
+        const tailSize = Math.min(fileSize, 64)
+        const buf = Buffer.alloc(tailSize)
+        fs.readSync(fd, buf, 0, tailSize, fileSize - tailSize)
         fs.closeSync(fd)
-        return buf[4] === 0x49 && buf[5] === 0x45 && buf[6] === 0x4E && buf[7] === 0x44
+        const trimmed = stripTrailingNulBytes(buf)
+        if (trimmed.length < 12) return false
+        const tail = trimmed.subarray(trimmed.length - 12)
+        return tail[4] === 0x49 && tail[5] === 0x45 && tail[6] === 0x4E && tail[7] === 0x44
       }
 
       if (ext.endsWith('.gif')) {
@@ -3283,10 +3292,9 @@ export class ImageDecryptService {
       proc.stdout.on('data', (chunk: Buffer) => chunks.push(chunk))
       proc.stderr.on('data', (chunk: Buffer) => errChunks.push(chunk))
 
-      // ffmpeg 提前退出（坏输入 / 坏二进制 / dyld 失败）时，stdin write 会异步抛 EPIPE。
+      // ffmpeg 提前退出（坏输入 / 坏二进制 / dyld 失败）时，stdin write 会异步抛 EPIPE/EOF。
       // 未监听会变成 Unhandled 'error' event，拖垮整个导出 utility process。
-      proc.stdin.on('error', (err: NodeJS.ErrnoException) => {
-        if (err.code === 'EPIPE' || err.code === 'ERR_STREAM_DESTROYED') return
+      attachClosedPipeStdinGuard(proc.stdin, (err) => {
         console.error('[ImageDecrypt] ffmpeg stdin error', err)
       })
 
@@ -3306,25 +3314,10 @@ export class ImageDecryptService {
       })
 
       // 写入数据并关闭（write 回调里 end，避免 pipe 已断时同步抛错）
-      try {
-        proc.stdin.write(hevcData, (writeErr: Error | null | undefined) => {
-          if (writeErr) {
-            const code = (writeErr as NodeJS.ErrnoException).code
-            if (code !== 'EPIPE' && code !== 'ERR_STREAM_DESTROYED') {
-              console.error('[ImageDecrypt] 写入 ffmpeg stdin 失败', writeErr)
-            }
-            return
-          }
-          try {
-            proc.stdin.end()
-          } catch {
-            /* ignore */
-          }
-        })
-      } catch (e) {
-        console.error('[ImageDecrypt] 写入 ffmpeg stdin 失败', e)
+      writeAndEndStdin(proc.stdin, hevcData, (err) => {
+        console.error('[ImageDecrypt] 写入 ffmpeg stdin 失败', err)
         finish(null)
-      }
+      })
     })
   }
 
@@ -3340,46 +3333,7 @@ export class ImageDecryptService {
    * 不完整的图片不应该被缓存，下次重新解密可能拿到完整数据
    */
   private verifyImageComplete(data: Buffer, ext: string): boolean {
-    if (!data || data.length < 100) return false
-
-    const lowerExt = ext.toLowerCase()
-
-    if (lowerExt === '.jpg' || lowerExt === '.jpeg') {
-      // JPEG: 检查是否存在 EOI marker (0xFF 0xD9)
-      // 从末尾往前搜索（有些 JPEG 在 EOI 后有少量附加数据）
-      const searchLen = Math.min(data.length, 64)
-      for (let i = data.length - 2; i >= data.length - searchLen; i--) {
-        if (data[i] === 0xFF && data[i + 1] === 0xD9) {
-          return true
-        }
-      }
-      // Motion Photo 情况：JPEG 后面紧跟 MP4，EOI 在中间位置
-      const quarterStart = Math.floor(data.length * 3 / 4)
-      for (let i = quarterStart; i < data.length - 1; i++) {
-        if (data[i] === 0xFF && data[i + 1] === 0xD9) {
-          return true
-        }
-      }
-      return false
-    }
-
-    if (lowerExt === '.png') {
-      // PNG: 末尾应有 IEND chunk (... 49 45 4E 44 AE 42 60 82)
-      if (data.length < 12) return false
-      const tail = data.subarray(data.length - 12)
-      if (tail[4] === 0x49 && tail[5] === 0x45 && tail[6] === 0x4E && tail[7] === 0x44) {
-        return true
-      }
-      return false
-    }
-
-    if (lowerExt === '.gif') {
-      // GIF: 末尾应有 trailer byte (0x3B)
-      return data[data.length - 1] === 0x3B
-    }
-
-    // WebP 和其他格式暂不做细粒度校验，仅检查最低大小
-    return data.length > 100
+    return verifyImageCompleteCore(data, ext)
   }
 
   private bufferToDataUrl(buffer: Buffer, ext: string): string | null {

--- a/electron/services/imageDecryptService.ts
+++ b/electron/services/imageDecryptService.ts
@@ -3244,6 +3244,14 @@ export class ImageDecryptService {
       const { spawn } = require('child_process')
       const chunks: Buffer[] = []
       const errChunks: Buffer[] = []
+      let settled = false
+
+      const finish = (result: Buffer | null) => {
+        if (settled) return
+        settled = true
+        clearTimeout(killTimer)
+        resolve(result)
+      }
 
       const args = [
         '-hide_banner',
@@ -3269,37 +3277,53 @@ export class ImageDecryptService {
         console.error('[ImageDecrypt] ffmpeg 转换超时，强制结束进程')
         if (hash) this.blacklistWxgfHash(hash)
         try { proc.kill() } catch { /* 已退出 */ }
-        resolve(null)
+        finish(null)
       }, 15000)
 
       proc.stdout.on('data', (chunk: Buffer) => chunks.push(chunk))
       proc.stderr.on('data', (chunk: Buffer) => errChunks.push(chunk))
 
+      // ffmpeg 提前退出（坏输入 / 坏二进制 / dyld 失败）时，stdin write 会异步抛 EPIPE。
+      // 未监听会变成 Unhandled 'error' event，拖垮整个导出 utility process。
+      proc.stdin.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EPIPE' || err.code === 'ERR_STREAM_DESTROYED') return
+        console.error('[ImageDecrypt] ffmpeg stdin error', err)
+      })
+
       proc.on('close', (code: number) => {
-        clearTimeout(killTimer)
         if (code === 0 && chunks.length > 0) {
-          const result = Buffer.concat(chunks)
-          resolve(result)
+          finish(Buffer.concat(chunks))
         } else {
           const errMsg = Buffer.concat(errChunks).toString()
           console.error(`[ImageDecrypt] ffmpeg 转换失败 code=${code} err=${errMsg}`)
-          resolve(null)
+          finish(null)
         }
       })
 
       proc.on('error', (err: any) => {
-        clearTimeout(killTimer)
         console.error(`[ImageDecrypt] ffmpeg 启动失败: ${ffmpeg}`, err)
-        resolve(null)
+        finish(null)
       })
 
-      // 写入数据并关闭
+      // 写入数据并关闭（write 回调里 end，避免 pipe 已断时同步抛错）
       try {
-        proc.stdin.write(hevcData)
-        proc.stdin.end()
+        proc.stdin.write(hevcData, (writeErr: Error | null | undefined) => {
+          if (writeErr) {
+            const code = (writeErr as NodeJS.ErrnoException).code
+            if (code !== 'EPIPE' && code !== 'ERR_STREAM_DESTROYED') {
+              console.error('[ImageDecrypt] 写入 ffmpeg stdin 失败', writeErr)
+            }
+            return
+          }
+          try {
+            proc.stdin.end()
+          } catch {
+            /* ignore */
+          }
+        })
       } catch (e) {
         console.error('[ImageDecrypt] 写入 ffmpeg stdin 失败', e)
-        resolve(null)
+        finish(null)
       }
     })
   }

--- a/scripts/test-dat-v3-plaintext.ts
+++ b/scripts/test-dat-v3-plaintext.ts
@@ -1,5 +1,6 @@
 /**
- * Regression: V3 plaintext .dat (already JPEG/PNG) must not be XOR-corrupted.
+ * Regression: V3 plaintext .dat must skip XOR; trailing NUL padding must still
+ * count as complete after stripTrailingNulBytes / verifyImageComplete.
  *
  * Run: npx tsx scripts/test-dat-v3-plaintext.ts
  */
@@ -7,18 +8,33 @@ import { mkdtempSync, writeFileSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { decryptDatLegacy, detectImageExtension } from '../electron/services/datDecryptCore'
+import { stripTrailingNulBytes, verifyImageComplete } from '../electron/services/imageComplete'
 
-const JPEG_HEAD = Buffer.from([
+const JPEG_MIN = Buffer.from([
   0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
-  0x01, 0x00, 0x00, 0x48, 0x00, 0x48, 0x00, 0x00, 0xff, 0xd9
+  0x01, 0x00, 0x00, 0x48, 0x00, 0x48, 0x00, 0x00, 0xff, 0xd9,
 ])
-const PNG_HEAD = Buffer.from([
+const PNG_MIN = Buffer.from([
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
   0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
   0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
   0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
-  0xde, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82
+  0xde, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
 ])
+
+function padToMinSize(data: Buffer, min = 120): Buffer {
+  if (data.length >= min) return data
+  // 在结束标记前填充非零字节，避免破坏 EOI/IEND；再由调用方自行加尾部 0x00
+  const body = Buffer.alloc(min - data.length, 0x11)
+  // JPEG: insert before last 2 bytes (EOI); PNG: insert before last 12 (IEND chunk)
+  if (data[0] === 0xff && data[1] === 0xd8) {
+    return Buffer.concat([data.subarray(0, data.length - 2), body, data.subarray(data.length - 2)])
+  }
+  if (data[0] === 0x89 && data[1] === 0x50) {
+    return Buffer.concat([data.subarray(0, data.length - 12), body, data.subarray(data.length - 12)])
+  }
+  return Buffer.concat([data, body])
+}
 
 function xorBuffer(data: Buffer, key: number): Buffer {
   const out = Buffer.alloc(data.length)
@@ -33,29 +49,54 @@ function assert(cond: unknown, msg: string): asserts cond {
 const dir = mkdtempSync(join(tmpdir(), 'ciphertalk-dat-v3-'))
 try {
   const xorKey = 0x73
+  const jpeg = padToMinSize(JPEG_MIN)
+  const png = padToMinSize(PNG_MIN)
 
-  // 1) Plaintext JPEG .dat + wrong/configured XOR key must stay JPEG
+  // 1) Plaintext JPEG .dat + configured XOR key must stay JPEG
   const plainJpg = join(dir, 'plain.jpg.dat')
-  writeFileSync(plainJpg, JPEG_HEAD)
+  writeFileSync(plainJpg, jpeg)
   const plainJpgOut = decryptDatLegacy(plainJpg, xorKey, null).data
   assert(detectImageExtension(plainJpgOut) === '.jpg', `plaintext jpg corrupted: ${plainJpgOut.subarray(0, 8).toString('hex')}`)
-  assert(plainJpgOut.equals(JPEG_HEAD), 'plaintext jpg bytes changed')
+  assert(plainJpgOut.equals(jpeg), 'plaintext jpg bytes changed')
 
   // 2) Plaintext PNG .dat
   const plainPng = join(dir, 'plain.png.dat')
-  writeFileSync(plainPng, PNG_HEAD)
+  writeFileSync(plainPng, png)
   const plainPngOut = decryptDatLegacy(plainPng, xorKey, null).data
   assert(detectImageExtension(plainPngOut) === '.png', `plaintext png corrupted: ${plainPngOut.subarray(0, 8).toString('hex')}`)
-  assert(plainPngOut.equals(PNG_HEAD), 'plaintext png bytes changed')
+  assert(plainPngOut.equals(png), 'plaintext png bytes changed')
 
-  // 3) Real V3 XOR-encrypted JPEG still decrypts with the key
+  // 3) Real V3 XOR-encrypted JPEG still decrypts
   const encJpg = join(dir, 'enc.jpg.dat')
-  writeFileSync(encJpg, xorBuffer(JPEG_HEAD, xorKey))
+  writeFileSync(encJpg, xorBuffer(jpeg, xorKey))
   const encJpgOut = decryptDatLegacy(encJpg, xorKey, null).data
   assert(detectImageExtension(encJpgOut) === '.jpg', `encrypted jpg failed: ${encJpgOut.subarray(0, 8).toString('hex')}`)
-  assert(encJpgOut.equals(JPEG_HEAD), 'encrypted jpg decrypt mismatch')
+  assert(encJpgOut.equals(jpeg), 'encrypted jpg decrypt mismatch')
 
-  console.log('PASS: V3 plaintext .dat skipped XOR; encrypted .dat still decrypts')
+  // 4) Trailing NUL padding: production PNG/JPEG must still be "complete"
+  const jpegPadded = Buffer.concat([jpeg, Buffer.alloc(16, 0x00)])
+  const pngPadded = Buffer.concat([png, Buffer.alloc(16, 0x00)])
+
+  assert(verifyImageComplete(jpegPadded, '.jpg'), 'JPEG with trailing NULs must be complete')
+  assert(verifyImageComplete(pngPadded, '.png'), 'PNG with trailing NULs must be complete')
+  // 对照：未裁剪且只看末 12 字节时 PNG 会失败（复现 review 场景）
+  const rawPngTail = pngPadded.subarray(pngPadded.length - 12)
+  assert(!(rawPngTail[4] === 0x49 && rawPngTail[5] === 0x45), 'sanity: raw padded PNG tail is not IEND')
+
+  const paddedJpgPath = join(dir, 'plain-pad.jpg.dat')
+  writeFileSync(paddedJpgPath, jpegPadded)
+  const paddedJpgOut = decryptDatLegacy(paddedJpgPath, xorKey, null).data
+  assert(paddedJpgOut.equals(jpeg), 'plaintext JPEG decrypt should strip trailing NULs')
+  assert(verifyImageComplete(paddedJpgOut, '.jpg'), 'stripped JPEG must verify complete')
+
+  const paddedPngPath = join(dir, 'plain-pad.png.dat')
+  writeFileSync(paddedPngPath, pngPadded)
+  const paddedPngOut = decryptDatLegacy(paddedPngPath, xorKey, null).data
+  assert(paddedPngOut.equals(png), 'plaintext PNG decrypt should strip trailing NULs')
+  assert(verifyImageComplete(paddedPngOut, '.png'), 'stripped PNG must verify complete')
+  assert(stripTrailingNulBytes(pngPadded).equals(png), 'stripTrailingNulBytes should remove pad')
+
+  console.log('PASS: V3 plaintext skip XOR; trailing NUL padding treated as complete')
 } finally {
   rmSync(dir, { recursive: true, force: true })
 }

--- a/scripts/test-dat-v3-plaintext.ts
+++ b/scripts/test-dat-v3-plaintext.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression: V3 plaintext .dat (already JPEG/PNG) must not be XOR-corrupted.
+ *
+ * Run: npx tsx scripts/test-dat-v3-plaintext.ts
+ */
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { decryptDatLegacy, detectImageExtension } from '../electron/services/datDecryptCore'
+
+const JPEG_HEAD = Buffer.from([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+  0x01, 0x00, 0x00, 0x48, 0x00, 0x48, 0x00, 0x00, 0xff, 0xd9
+])
+const PNG_HEAD = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+  0xde, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82
+])
+
+function xorBuffer(data: Buffer, key: number): Buffer {
+  const out = Buffer.alloc(data.length)
+  for (let i = 0; i < data.length; i++) out[i] = data[i] ^ key
+  return out
+}
+
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) throw new Error(msg)
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'ciphertalk-dat-v3-'))
+try {
+  const xorKey = 0x73
+
+  // 1) Plaintext JPEG .dat + wrong/configured XOR key must stay JPEG
+  const plainJpg = join(dir, 'plain.jpg.dat')
+  writeFileSync(plainJpg, JPEG_HEAD)
+  const plainJpgOut = decryptDatLegacy(plainJpg, xorKey, null).data
+  assert(detectImageExtension(plainJpgOut) === '.jpg', `plaintext jpg corrupted: ${plainJpgOut.subarray(0, 8).toString('hex')}`)
+  assert(plainJpgOut.equals(JPEG_HEAD), 'plaintext jpg bytes changed')
+
+  // 2) Plaintext PNG .dat
+  const plainPng = join(dir, 'plain.png.dat')
+  writeFileSync(plainPng, PNG_HEAD)
+  const plainPngOut = decryptDatLegacy(plainPng, xorKey, null).data
+  assert(detectImageExtension(plainPngOut) === '.png', `plaintext png corrupted: ${plainPngOut.subarray(0, 8).toString('hex')}`)
+  assert(plainPngOut.equals(PNG_HEAD), 'plaintext png bytes changed')
+
+  // 3) Real V3 XOR-encrypted JPEG still decrypts with the key
+  const encJpg = join(dir, 'enc.jpg.dat')
+  writeFileSync(encJpg, xorBuffer(JPEG_HEAD, xorKey))
+  const encJpgOut = decryptDatLegacy(encJpg, xorKey, null).data
+  assert(detectImageExtension(encJpgOut) === '.jpg', `encrypted jpg failed: ${encJpgOut.subarray(0, 8).toString('hex')}`)
+  assert(encJpgOut.equals(JPEG_HEAD), 'encrypted jpg decrypt mismatch')
+
+  console.log('PASS: V3 plaintext .dat skipped XOR; encrypted .dat still decrypts')
+} finally {
+  rmSync(dir, { recursive: true, force: true })
+}

--- a/scripts/test-ffmpeg-stdin-epipe.ts
+++ b/scripts/test-ffmpeg-stdin-epipe.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression: writing to a child process stdin after it exits must not crash
+ * via unhandled 'error' (EPIPE). Mirrors imageDecryptService.convertHevcToJpg.
+ *
+ * Run: npx tsx scripts/test-ffmpeg-stdin-epipe.ts
+ */
+import { spawn } from 'child_process'
+
+const CLOSED = new Set(['EPIPE', 'ERR_STREAM_DESTROYED'])
+
+function writeHevcLike(handleStdinError: boolean): Promise<'ok' | 'unhandled'> {
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (result: 'ok' | 'unhandled') => {
+      if (settled) return
+      settled = true
+      resolve(result)
+    }
+
+    const onUnhandled = (err: Error) => {
+      const code = (err as NodeJS.ErrnoException).code
+      if (code === 'EPIPE' || err.message?.includes('EPIPE')) {
+        finish('unhandled')
+      }
+    }
+    process.once('uncaughtException', onUnhandled)
+
+    // Exit immediately so stdin writes race against a closed pipe.
+    const proc = spawn(process.execPath, ['-e', 'process.exit(0)'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    if (handleStdinError) {
+      proc.stdin.on('error', (err: NodeJS.ErrnoException) => {
+        if (CLOSED.has(String(err.code))) return
+        console.error('unexpected stdin error', err)
+      })
+    }
+
+    proc.on('error', () => finish('ok'))
+    proc.on('close', () => {
+      // Give async EPIPE a moment to surface if unhandled.
+      setTimeout(() => {
+        process.off('uncaughtException', onUnhandled)
+        finish('ok')
+      }, 100)
+    })
+
+    const payload = Buffer.alloc(256 * 1024, 1)
+    const tryWrite = () => {
+      try {
+        proc.stdin.write(payload, () => {
+          try {
+            proc.stdin.end()
+          } catch {
+            /* ignore */
+          }
+        })
+      } catch {
+        /* sync write failure is fine */
+      }
+    }
+
+    // Write both immediately and after close to maximize EPIPE chance.
+    tryWrite()
+    setTimeout(tryWrite, 20)
+  })
+}
+
+async function main() {
+  const withHandler = await writeHevcLike(true)
+  if (withHandler !== 'ok') {
+    console.error('FAIL: handled stdin still surfaced unhandled EPIPE')
+    process.exit(1)
+  }
+
+  // Without handler, Node may throw unhandled EPIPE — we only assert the
+  // guarded path is safe (production fix). Unguarded crash is platform-timing
+  // dependent; skip hard assert there.
+  console.log('PASS: stdin EPIPE handler prevents process crash')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/test-ffmpeg-stdin-epipe.ts
+++ b/scripts/test-ffmpeg-stdin-epipe.ts
@@ -1,45 +1,59 @@
 /**
- * Regression: writing to a child process stdin after it exits must not crash
- * via unhandled 'error' (EPIPE). Mirrors imageDecryptService.convertHevcToJpg.
+ * Regression: closed-pipe stdin errors (EPIPE / ERR_STREAM_DESTROYED / Windows EOF)
+ * must be handled by the shared guard used in convertHevcToJpg.
  *
  * Run: npx tsx scripts/test-ffmpeg-stdin-epipe.ts
  */
 import { spawn } from 'child_process'
+import {
+  attachClosedPipeStdinGuard,
+  isClosedPipeError,
+  writeAndEndStdin,
+} from '../electron/services/closedPipeStdin'
 
-const CLOSED = new Set(['EPIPE', 'ERR_STREAM_DESTROYED'])
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) throw new Error(msg)
+}
 
-function writeHevcLike(handleStdinError: boolean): Promise<'ok' | 'unhandled'> {
+// Unit: classifier
+assert(isClosedPipeError({ code: 'EPIPE' }), 'EPIPE should be closed-pipe')
+assert(isClosedPipeError({ code: 'ERR_STREAM_DESTROYED' }), 'ERR_STREAM_DESTROYED should be closed-pipe')
+assert(isClosedPipeError({ code: 'EOF' }), 'Windows EOF should be closed-pipe')
+assert(!isClosedPipeError({ code: 'EACCES' }), 'EACCES must not be closed-pipe')
+
+function writeWithGuard(handleStdinError: boolean): Promise<{
+  result: 'ok' | 'unhandled'
+  unexpected: Error[]
+}> {
   return new Promise((resolve) => {
     let settled = false
+    const unexpected: Error[] = []
     const finish = (result: 'ok' | 'unhandled') => {
       if (settled) return
       settled = true
-      resolve(result)
+      resolve({ result, unexpected })
     }
 
     const onUnhandled = (err: Error) => {
       const code = (err as NodeJS.ErrnoException).code
-      if (code === 'EPIPE' || err.message?.includes('EPIPE')) {
+      if (isClosedPipeError(err) || code === 'EPIPE' || err.message?.includes('EPIPE')) {
         finish('unhandled')
       }
     }
     process.once('uncaughtException', onUnhandled)
 
-    // Exit immediately so stdin writes race against a closed pipe.
     const proc = spawn(process.execPath, ['-e', 'process.exit(0)'], {
       stdio: ['pipe', 'pipe', 'pipe'],
     })
 
     if (handleStdinError) {
-      proc.stdin.on('error', (err: NodeJS.ErrnoException) => {
-        if (CLOSED.has(String(err.code))) return
-        console.error('unexpected stdin error', err)
+      attachClosedPipeStdinGuard(proc.stdin, (err) => {
+        unexpected.push(err)
       })
     }
 
     proc.on('error', () => finish('ok'))
     proc.on('close', () => {
-      // Give async EPIPE a moment to surface if unhandled.
       setTimeout(() => {
         process.off('uncaughtException', onUnhandled)
         finish('ok')
@@ -48,36 +62,25 @@ function writeHevcLike(handleStdinError: boolean): Promise<'ok' | 'unhandled'> {
 
     const payload = Buffer.alloc(256 * 1024, 1)
     const tryWrite = () => {
-      try {
-        proc.stdin.write(payload, () => {
-          try {
-            proc.stdin.end()
-          } catch {
-            /* ignore */
-          }
-        })
-      } catch {
-        /* sync write failure is fine */
-      }
+      writeAndEndStdin(proc.stdin, payload, (err) => {
+        unexpected.push(err)
+      })
     }
 
-    // Write both immediately and after close to maximize EPIPE chance.
     tryWrite()
     setTimeout(tryWrite, 20)
   })
 }
 
 async function main() {
-  const withHandler = await writeHevcLike(true)
-  if (withHandler !== 'ok') {
-    console.error('FAIL: handled stdin still surfaced unhandled EPIPE')
-    process.exit(1)
-  }
+  const withHandler = await writeWithGuard(true)
+  assert(withHandler.result === 'ok', 'FAIL: handled stdin still surfaced unhandled closed-pipe error')
+  assert(
+    withHandler.unexpected.length === 0,
+    `FAIL: unexpected stdin errors should fail the test, got: ${withHandler.unexpected.map((e) => (e as NodeJS.ErrnoException).code || e.message).join(', ')}`
+  )
 
-  // Without handler, Node may throw unhandled EPIPE — we only assert the
-  // guarded path is safe (production fix). Unguarded crash is platform-timing
-  // dependent; skip hard assert there.
-  console.log('PASS: stdin EPIPE handler prevents process crash')
+  console.log('PASS: stdin closed-pipe guard (EPIPE/EOF) prevents process crash')
 }
 
 main().catch((err) => {

--- a/scripts/test-file-url-to-local-path.ts
+++ b/scripts/test-file-url-to-local-path.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { pathToFileURL } from 'node:url'
+import { localPathFromFileUrl } from '../electron/services/fileUrlPath.ts'
+
+const abs = '/Users/kelaocai/Documents/CipherTalkData/Images/meeaaw/2021-04/x_hd.jpg'
+const withQuery = `${pathToFileURL(abs).toString()}?v=1785329966729`
+
+assert.equal(
+  localPathFromFileUrl(withQuery),
+  abs,
+  'file:///…?v=… must keep leading slash on macOS/Linux',
+)
+
+assert.equal(
+  localPathFromFileUrl(pathToFileURL(abs).toString()),
+  abs,
+  'file:/// without query must round-trip',
+)
+
+assert.equal(
+  localPathFromFileUrl(abs),
+  abs,
+  'plain absolute paths must pass through',
+)
+
+console.log('file url to local path: ok')


### PR DESCRIPTION
## PR说明

导出带图片时，容易遇到三类问题：

1. **导出进程直接挂掉**（日志里有 `EPIPE` / Windows 上还有 `EOF`）
2. **很多旧图片解出来是坏的**，疯狂刷「图片不完整」，`headHex` 像 `8cab8c93…`
3. **macOS 上明明解了，导出目录却一张都没有**（进度一直「图 0」）

本 PR 把这三块一起修好了，并按主仓库 review 意见补了尾部零填充和 Windows EOF。

---

## 原因分析

### 1）ffmpeg 管子断了还在写 → 整进程崩

转 wxgf/HEVC 时，会把数据灌进 ffmpeg 的 stdin。  
ffmpeg 如果提前退出（坏图、二进制有问题等），后面再写就会报 `EPIPE`（Windows 常是 `EOF`）。  
以前没接住这个错误，Node 当成未处理异常，**整个导出子进程直接死掉**。

### 2）旧微信有的 `.dat` 其实已经是明文图，却还在 XOR

有些老会话的 `_M.dat` 本身已经是 JPEG/PNG，不是加密数据。  
程序仍按配置的密钥（比如 `0x73`）整文件异或，等于把好好的图「解坏」。  
`ffd8ffe0` XOR `0x73` → `8cab8c93`，正好对上日志里的乱码头。

另外这些明文文件尾部常垫一串 `0x00`。PNG 校验要求结尾必须是 IEND，**有零填充就会被误判「不完整」**。

### 3）macOS 路径少了开头的 `/` → 文件找不着，一张都不拷

解密成功后返回的是 `file:///Users/...`。  
导出这边用字符串抠掉 `file:///`，结果把路径开头的 `/` 也抠没了，变成相对路径 `Users/...`。  
`existsSync` 失败，静默跳过，所以一直是 **图 0、目录空空**。

---

## 怎么改的

| 问题 | 改法 |
|------|------|
| 进程崩溃 | 抽出共用的 `closedPipeStdin`：`EPIPE` / `ERR_STREAM_DESTROYED` / `EOF` 都当「管子正常关了」；测试直接跑这套逻辑，遇到未知错误会 FAIL |
| 明文被解坏 | `decryptDatV3`：已经是图片签名就跳过 XOR，并裁掉尾部 `0x00` |
| 零填充误判 | `imageComplete`：校验前先裁尾部零；落盘也用裁过的数据 |
| 导出图 0 | `fileUrlPath` + `fileURLToPath`，图片/视频导出都改用正确本地路径 |

真正还在 XOR 加密的 V3 `.dat`，行为不变。

---

## 怎么测

```bash
npx tsx scripts/test-ffmpeg-stdin-epipe.ts
npx tsx scripts/test-dat-v3-plaintext.ts
npx tsx scripts/test-file-url-to-local-path.ts
```

建议再手动测：

- [ ] 导出带 wxgf 的会话：媒体阶段不要再因 EPIPE/EOF 整进程退出
- [ ] 导出 2020–2021 左右旧图：别再刷 `8cab8c93…` 那种「不完整」；目录里能看到图
- [ ] 带尾部零填充的明文 PNG：不要再误报不完整
- [ ] macOS 导出：进度里图片数 > 0，导出目录有图
- [ ] 抽几张仍是 XOR 加密的 V3 图：仍能正常解出来