### PR TITLE
fix(moments): 修复朋友圈缩略图可显示但点击预览裂图

### DIFF
--- a/src/pages/MomentsWindow.tsx
+++ b/src/pages/MomentsWindow.tsx
@@ -468,16 +468,14 @@ const MediaItem = ({ media, isSingle, allMedia, onPreview }: { media: any; isSin
 
     try {
       if (isVideo) {
-        // 视频：使用视频播放器窗口
+        // 视频：使用视频播放器窗口（需保留 file://，查看器直接当 <video src> 用）
         if (videoPath) {
-          const localPath = videoPath.replace(/^file:\/\//, '')
-          await window.electronAPI.window.openVideoPlayerWindow(localPath)
+          await window.electronAPI.window.openVideoPlayerWindow(videoPath)
         }
       } else {
-        // 图片：使用图片查看器窗口
+        // 图片：使用图片查看器窗口（需保留 file:// / data:，查看器直接当 <img src> 用）
         if (thumbSrc) {
-          const localPath = thumbSrc.replace(/^file:\/\//, '')
-          const liveVideoLocalPath = isLive && liveVideoPath ? liveVideoPath.replace(/^file:\/\//, '') : undefined
+          const liveVideoSrc = isLive && liveVideoPath ? liveVideoPath : undefined
 
           // 从缓存构建同一条动态的图片列表
           let imageList: Array<{ imagePath: string; liveVideoPath?: string }> | undefined
@@ -489,15 +487,15 @@ const MediaItem = ({ media, isSingle, allMedia, onPreview }: { media: any; isSin
               const cached = mediaPathCache.get(key)
               if (cached) {
                 list.push({
-                  imagePath: cached.imagePath.replace(/^file:\/\//, ''),
-                  liveVideoPath: cached.liveVideoPath?.replace(/^file:\/\//, '')
+                  imagePath: cached.imagePath,
+                  liveVideoPath: cached.liveVideoPath
                 })
               }
             }
             if (list.length > 1) imageList = list
           }
 
-          await window.electronAPI.window.openImageViewerWindow(localPath, liveVideoLocalPath, imageList)
+          await window.electronAPI.window.openImageViewerWindow(thumbSrc, liveVideoSrc, imageList)
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- 朋友圈点击图片/视频预览时，不再错误剥掉 `file://` 前缀
- 查看器窗口的 `<img>` / `<video>` 需要完整本地 URL；剥成裸磁盘路径后，在页面上下文中会被当成站点路径，导致预览裂图（缩略图本身正常）
- 与聊天记录打开图片查看器的路径处理方式对齐

## Test plan
- [ ] 打开朋友圈，确认缩略图仍正常显示
- [ ] 点击单张图片，确认独立图片查看器能正常显示
- [ ] 点击多图动态中的任意图片，确认可预览且左右切换正常
- [ ] 点击视频，确认视频播放器能正常打开
- [ ] 若有 Live Photo，确认实况视频仍可播放

