### PR TITLE
fix(export): 修复转发聊天记录的发言人被错误计入导出成员列表

### DIFF
--- a/electron/services/exportService.ts
+++ b/electron/services/exportService.ts
@@ -1,4 +1,4 @@
-﻿import * as fs from 'fs'
+import * as fs from 'fs'
 import * as path from 'path'
 import * as https from 'https'
 import * as http from 'http'
@@ -996,15 +996,6 @@ class ExportService {
             }
 
             chatRecords.push(chatRecord)
-
-            // 添加成员信息
-            if (record.sourcename && !memberSet.has(record.sourcename)) {
-              memberSet.set(record.sourcename, {
-                platformId: record.sourcename,
-                accountName: record.sourcename,
-                ...(options.exportAvatars && record.sourceheadurl && { avatar: record.sourceheadurl })
-              })
-            }
           }
 
           message.chatRecords = chatRecords
@@ -2018,19 +2009,6 @@ class ExportService {
                 name: senderInfo.displayName,
                 avatar: options.exportAvatars ? senderInfo.avatarUrl : undefined
               })
-            }
-
-            // 收集聊天记录中的成员
-            if (chatRecordList) {
-              for (const record of chatRecordList) {
-                if (record.sourcename && !memberSet.has(record.sourcename)) {
-                  memberSet.set(record.sourcename, {
-                    id: record.sourcename,
-                    name: record.sourcename,
-                    avatar: options.exportAvatars ? record.sourceheadurl : undefined
-                  })
-                }
-              }
             }
           }
           expStep('HTML: 读取会话消息(下一页)')


### PR DESCRIPTION
## 问题

私聊（两人对话）导出的聊天记录中，`members` 列表出现了多个与对话无关的第三方成员。

## 原因

当会话中包含**合并转发的聊天记录消息**（XML type=19 / localType=49）时，导出逻辑会把该记录里每条原始消息的发送者 `record.sourcename` 也加入顶层 `members` 列表。这些人是被转发内容里的发言人，并非当前会话的参与者——私聊、群聊场景下都不正确。

## 修复

`electron/services/exportService.ts` 两条导出路径均移除该行为：

- ChatLab 导出：删除构建嵌套 `chatRecords` 时向 `memberSet` 写入 `record.sourcename` 的逻辑
- HTML/JSON 导出：删除"收集聊天记录中的成员"逻辑

信息无丢失：每条转发记录内部仍保留自己的 `sender` / `accountName` / `avatar` 字段，HTML 渲染也直接从 `msg.chatRecords` 取数据，不依赖顶层 `members` 表。

修复后私聊导出的 `members` 只包含真正的对话双方。

已通过 `tsc --noEmit` 类型检查。