### PR TITLE
fix(auth): 常数时间密码比较 + 升级 sherpa-onnx-node 修复漏洞

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "qrcode": "^1.5.4",
         "radix-ui": "^1.4.3",
         "sharp": "^0.34.5",
-        "sherpa-onnx-node": "^1.12.23",
+        "sherpa-onnx-node": "^1.13.4",
         "shiki": "^4.2.0",
         "silk-wasm": "^3.7.1",
         "streamdown": "^2.5.0",
@@ -19293,8 +19293,8 @@
       }
     },
     "node_modules/sherpa-onnx-darwin-arm64": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.13.2.tgz",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.13.4.tgz",
       "integrity": "sha512-sakY1+WH/Va/vhzwlhIKXaMr0ioKsJ55w785QH+VDFyUqq1+2InbmB3BgX5gyYKeuW40R0U0IW5c7wnMArhpdw==",
       "cpu": [
         "arm64"
@@ -19306,8 +19306,8 @@
       ]
     },
     "node_modules/sherpa-onnx-darwin-x64": {
-      "version": "1.12.40",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.12.40.tgz",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.13.4.tgz",
       "integrity": "sha512-ks+A+ecmgpy3BiVmVkSW4S7W7ce4XSjE3/ueIUtiMzuGr4Tv/+Jzae4EPTWME66CmEw2iDPSIkHci9A7ogNU+w==",
       "cpu": [
         "x64"
@@ -19319,8 +19319,8 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-arm64": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.13.2.tgz",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.13.4.tgz",
       "integrity": "sha512-IJNyd6ORcMpy1oR2ZXGNidRiPuIh5KWoOYSIOhW9UQ/BUIY43P6fq8Y3XcFj1xNjBtwke7keMW9DA7ZPYxlYoQ==",
       "cpu": [
         "arm64"
@@ -19332,8 +19332,8 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-x64": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.13.2.tgz",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.13.4.tgz",
       "integrity": "sha512-CI2pTKgbOTOpAbm6cSwsFzJZ9qD+xcpEKPfmMCMI7KjaEePnTfky+FYxVBvllbYNk9DQznuTT0Ob9XsBhwtE/Q==",
       "cpu": [
         "x64"
@@ -19345,20 +19345,20 @@
       ]
     },
     "node_modules/sherpa-onnx-node": {
-      "version": "1.12.25",
+      "version": "1.13.4",
       "license": "Apache-2.0",
       "optionalDependencies": {
-        "sherpa-onnx-darwin-arm64": "^1.12.25",
-        "sherpa-onnx-darwin-x64": "^1.12.25",
-        "sherpa-onnx-linux-arm64": "^1.12.25",
-        "sherpa-onnx-linux-x64": "^1.12.25",
-        "sherpa-onnx-win-ia32": "^1.12.25",
-        "sherpa-onnx-win-x64": "^1.12.25"
+        "sherpa-onnx-darwin-arm64": "^1.13.4",
+        "sherpa-onnx-darwin-x64": "^1.13.4",
+        "sherpa-onnx-linux-arm64": "^1.13.4",
+        "sherpa-onnx-linux-x64": "^1.13.4",
+        "sherpa-onnx-win-ia32": "^1.13.4",
+        "sherpa-onnx-win-x64": "^1.13.4"
       }
     },
     "node_modules/sherpa-onnx-win-ia32": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.13.2.tgz",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.13.4.tgz",
       "integrity": "sha512-PJxFuZB6VcwxscP9whLdxBMhHWZ88Ax35LeKpAZWXIvFjIviX1yPJB1+ndhXvF9Nh1L8gPgO9MUBfC1BMKqzvw==",
       "cpu": [
         "ia32"
@@ -19370,7 +19370,7 @@
       ]
     },
     "node_modules/sherpa-onnx-win-x64": {
-      "version": "1.12.25",
+      "version": "1.13.4",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "qrcode": "^1.5.4",
     "radix-ui": "^1.4.3",
     "sharp": "^0.34.5",
-    "sherpa-onnx-node": "^1.12.23",
+    "sherpa-onnx-node": "^1.13.4",
     "shiki": "^4.2.0",
     "silk-wasm": "^3.7.1",
     "streamdown": "^2.5.0",

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import * as configService from '../services/config'
 import { fromBase64Url } from '@/utils/base64'
+import { timingSafeEqualHex } from '@/utils/crypto'
 
 interface AuthState {
     isAuthEnabled: boolean
@@ -211,7 +212,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
             const { hash } = await hashPassword(password, savedSalt)
 
-            if (hash === savedHash) {
+            if (timingSafeEqualHex(hash, savedHash)) {
                 set({
                     isLocked: false,
                     isAuthenticated: true

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -28,3 +28,21 @@ export async function hashPassword(password: string, salt?: string): Promise<{ h
 
     return { hash: hashHex, salt: saltStr };
 }
+
+/**
+ * 常数时间字符串比较（防 timing attack）。
+ * Web Crypto 没有 timingSafeEqual，这里手动实现：遍历全部字节累积差异，
+ * 执行时间与内容无关。长度不同直接返回 false（hash 长度固定为 64 hex，
+ * 长度本身不泄露有用信息）。
+ */
+export function timingSafeEqualHex(a: string, b: string): boolean {
+    const aBytes = new TextEncoder().encode(a);
+    const bBytes = new TextEncoder().encode(b);
+    if (aBytes.length !== bBytes.length) return false;
+
+    let diff = 0;
+    for (let i = 0; i < aBytes.length; i++) {
+        diff |= aBytes[i] ^ bBytes[i];
+    }
+    return diff === 0;
+}


### PR DESCRIPTION
## Summary
两个安全修复：

1. **时序攻击（CWE-208）**：`verifyPassword` 用 `hash === savedHash` 字符串比较，攻击者可利用比较耗时差异爆破密码。改为常数时间比较 `timingSafeEqualHex()`（Web Crypto 环境手动实现，遍历全部字节累积差异，执行时间与内容无关）。

2. **sherpa-onnx-node 缓冲区溢出（CWE-787/125）**：1.12.25 → 1.13.4，上游已修复。

## Changes
- `src/utils/crypto.ts`: 新增 `timingSafeEqualHex()`
- `src/stores/authStore.ts`: 密码验证改用常数时间比较
- `package.json` / `package-lock.json`: sherpa-onnx-node 1.13.4（仅 sherpa 相关条目）

## Test plan
- [ ] `tsc --noEmit` 通过
- [ ] 相同/不同/长度不等的 hash 比较结果正确
- [ ] 密码锁功能正常