### PR TITLE
fix(skills): 修复跨盘导入时 rename 失败（EXDEV）

### DIFF
--- a/electron/services/skillManagerService.ts
+++ b/electron/services/skillManagerService.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron'
-import { existsSync, readFileSync, writeFileSync, readdirSync, rmSync, mkdirSync, mkdtempSync, renameSync, statSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync, readdirSync, rmSync, mkdirSync, mkdtempSync, renameSync, cpSync, statSync } from 'fs'
 import { basename, isAbsolute, join, relative, resolve } from 'path'
 import AdmZip from 'adm-zip'
 import type { AgentSkillContextItem } from './agent/types'
@@ -438,7 +438,17 @@ export class SkillManagerService {
         return { success: false, error: `Skill directory "${skillName}" already exists` }
       }
 
-      renameSync(extractedDir, destDir)
+      // rename 在同一文件系统内是原子的；但 tempDir 建在 userData（可能 C 盘），
+      // 目标 skills 目录可能是另一个盘（如 D 盘），跨设备 rename 会抛 EXDEV。
+      // 失败时回退为「复制 + 删除」，保证跨盘导入可用（#280）。
+      try {
+        renameSync(extractedDir, destDir)
+      } catch (renameError: unknown) {
+        const code = (renameError as NodeJS.ErrnoException)?.code
+        if (code !== 'EXDEV') throw renameError
+        cpSync(extractedDir, destDir, { recursive: true })
+        rmSync(extractedDir, { recursive: true, force: true })
+      }
       this.invalidateSkillCaches()
       return { success: true, skillName }
     } catch (error) {


### PR DESCRIPTION
## Summary
修复 #280：Windows 下导入 skill zip 时，解压到 userData 临时目录（如 C 盘）后 `renameSync` 到目标 skills 目录（如 D 盘），跨设备 rename 抛 `EXDEV: cross-device link not permitted`。

## Change
`renameSync` 失败且错误码为 `EXDEV` 时，回退为 `cpSync` + `rmSync` 复制迁移；其他错误保持原样抛出。同盘导入仍走原子 rename，不受影响。

## Test plan
- [ ] `tsc --noEmit` 通过
- [ ] 同盘导入正常（rename 路径）
- [ ] 跨盘导入成功（copy 路径）

Closes #280