### PR TITLE
fix(chat): 消息库扫描纳入 biz_message_*.db，修复公众号消息空白

### DIFF
--- a/electron/services/dbStoragePaths.ts
+++ b/electron/services/dbStoragePaths.ts
@@ -70,7 +70,9 @@ function collectByName(root: string, matcher: (name: string) => boolean, depth =
 }
 
 function isMessageDbName(name: string): boolean {
-  return /^(?:msg|message)_\d+\.db$/i.test(name)
+  // 私聊/群聊消息在 message_*.db / msg_*.db；公众号消息在 biz_message_*.db，
+  // 漏掉会导致公众号会话查不到消息表、右侧空白。biz_message 表结构与普通消息库一致。
+  return /^(?:msg|message|biz_message)_\d+\.db$/i.test(name)
 }
 
 function collectDirectFiles(root: string, matcher: (name: string) => boolean): string[] {


### PR DESCRIPTION
## Summary
修复公众号会话右侧消息空白的问题。

## 现象
私聊/群聊消息正常，公众号（gh_ 开头或纯字母 id）点开后右侧空白。日志显示 `未匹配到消息表: session=gh_xxx`。

## 原因
微信把公众号消息存在 `biz_message_*.db`（与普通消息库 `message_*.db` 并列），但 `findMessageDbPaths` 只扫描 `msg_*.db / message_*.db`，漏掉了 `biz_message_*.db`，导致公众号会话找不到消息表。

## Change
`isMessageDbName` 正则加入 `biz_message` 前缀，一行改动。biz_message 表结构与普通消息库一致（Msg_<md5>），纳入扫描即可。

## 测试
- [ ] 私聊/群聊正常（回归）
- [ ] gh_ 开头公众号能显示消息
- [ ] 纯字母 id 公众号（如 mcdonalds888）能显示消息