### PR TITLE
fix(auth): 密码验证改用常数时间比较，防时序攻击

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import * as configService from '../services/config'
 import { fromBase64Url } from '@/utils/base64'
+import { timingSafeEqualHex } from '@/utils/crypto'
 
 interface AuthState {
     isAuthEnabled: boolean
@@ -211,7 +212,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
             const { hash } = await hashPassword(password, savedSalt)
 
-            if (hash === savedHash) {
+            if (timingSafeEqualHex(hash, savedHash)) {
                 set({
                     isLocked: false,
                     isAuthenticated: true

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -28,3 +28,21 @@ export async function hashPassword(password: string, salt?: string): Promise<{ h
 
     return { hash: hashHex, salt: saltStr };
 }
+
+/**
+ * 常数时间字符串比较（防 timing attack）。
+ * Web Crypto 没有 timingSafeEqual，这里手动实现：遍历全部字节累积差异，
+ * 执行时间与内容无关。长度不同直接返回 false（hash 长度固定为 64 hex，
+ * 长度本身不泄露有用信息）。
+ */
+export function timingSafeEqualHex(a: string, b: string): boolean {
+    const aBytes = new TextEncoder().encode(a);
+    const bBytes = new TextEncoder().encode(b);
+    if (aBytes.length !== bBytes.length) return false;
+
+    let diff = 0;
+    for (let i = 0; i < aBytes.length; i++) {
+        diff |= aBytes[i] ^ bBytes[i];
+    }
+    return diff === 0;
+}


### PR DESCRIPTION
## Summary
本地应用锁屏密码的哈希比较从字符串 `===` 改为常数时间比较（CWE-208，防御纵深）。Web Crypto 没有 `timingSafeEqual`，手动实现遍历全部字节累积差异，执行时间与内容无关。

按上轮 review 建议从 #321 拆出单独提交，便于独立合入或回退。

## Changes
- `src/utils/crypto.ts`: 新增 `timingSafeEqualHex()`
- `src/stores/authStore.ts`: 密码验证改用常数时间比较

## Test plan
- [x] `tsc --noEmit` 通过
- [ ] 密码锁功能正常（设置 / 验证 / 错误密码提示）