### PR TITLE
chore(deps): 升级 sherpa-onnx-node 至 1.13.4，修复 TopkIndex 缓冲区溢出

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "qrcode": "^1.5.4",
         "radix-ui": "^1.4.3",
         "sharp": "^0.34.5",
-        "sherpa-onnx-node": "^1.12.23",
+        "sherpa-onnx-node": "^1.13.4",
         "shiki": "^4.2.0",
         "silk-wasm": "^3.7.1",
         "streamdown": "^2.5.0",
@@ -19293,9 +19293,9 @@
       }
     },
     "node_modules/sherpa-onnx-darwin-arm64": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.13.2.tgz",
-      "integrity": "sha512-sakY1+WH/Va/vhzwlhIKXaMr0ioKsJ55w785QH+VDFyUqq1+2InbmB3BgX5gyYKeuW40R0U0IW5c7wnMArhpdw==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.13.4.tgz",
+      "integrity": "sha512-QcYKzyrTzGSx6aKCD6hUODgRS1LetqfG57Z/+i5LCyfMlrgCvDc1lRcl9cdB+TozBsLha9QwLTlI0vmDcf5JKg==",
       "cpu": [
         "arm64"
       ],
@@ -19306,9 +19306,9 @@
       ]
     },
     "node_modules/sherpa-onnx-darwin-x64": {
-      "version": "1.12.40",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.12.40.tgz",
-      "integrity": "sha512-ks+A+ecmgpy3BiVmVkSW4S7W7ce4XSjE3/ueIUtiMzuGr4Tv/+Jzae4EPTWME66CmEw2iDPSIkHci9A7ogNU+w==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.13.4.tgz",
+      "integrity": "sha512-6RGeis9K9gV/UQWOgd6Rf3iqXr2/YsBQswxHaCR4hrYkHfEIpHMfFmRWLt6nJJCOWgYW2xFxEd9yzjrafAV/Pw==",
       "cpu": [
         "x64"
       ],
@@ -19319,9 +19319,9 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-arm64": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.13.2.tgz",
-      "integrity": "sha512-IJNyd6ORcMpy1oR2ZXGNidRiPuIh5KWoOYSIOhW9UQ/BUIY43P6fq8Y3XcFj1xNjBtwke7keMW9DA7ZPYxlYoQ==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.13.4.tgz",
+      "integrity": "sha512-RMjMRqT82BgTXypNNGmLe6ZFYhc3WEvnAGl3DdkK7qB/kuXwkL3iHhV31wAecbnWPsnEpUoD+8cFovWSBzsCuw==",
       "cpu": [
         "arm64"
       ],
@@ -19332,9 +19332,9 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-x64": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.13.2.tgz",
-      "integrity": "sha512-CI2pTKgbOTOpAbm6cSwsFzJZ9qD+xcpEKPfmMCMI7KjaEePnTfky+FYxVBvllbYNk9DQznuTT0Ob9XsBhwtE/Q==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.13.4.tgz",
+      "integrity": "sha512-WZh5NCkGPFHHpYSd78iN4OnmxQeSTGyt9uZskH+im/NFHQ7elQ7B0sLzCMeRpvJxiIKvd9C6WxIJ4hYaxClfsQ==",
       "cpu": [
         "x64"
       ],
@@ -19345,21 +19345,23 @@
       ]
     },
     "node_modules/sherpa-onnx-node": {
-      "version": "1.12.25",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-node/-/sherpa-onnx-node-1.13.4.tgz",
+      "integrity": "sha512-jHWWdY9f0dbvJpdsfR/C4WNhM57+jT9Os2RyC4/qUz8HKCtj2VYFmJ9s7tue9OCFRAmdoGBkgkqD6aBZ3I8BKw==",
       "license": "Apache-2.0",
       "optionalDependencies": {
-        "sherpa-onnx-darwin-arm64": "^1.12.25",
-        "sherpa-onnx-darwin-x64": "^1.12.25",
-        "sherpa-onnx-linux-arm64": "^1.12.25",
-        "sherpa-onnx-linux-x64": "^1.12.25",
-        "sherpa-onnx-win-ia32": "^1.12.25",
-        "sherpa-onnx-win-x64": "^1.12.25"
+        "sherpa-onnx-darwin-arm64": "^1.13.4",
+        "sherpa-onnx-darwin-x64": "^1.13.4",
+        "sherpa-onnx-linux-arm64": "^1.13.4",
+        "sherpa-onnx-linux-x64": "^1.13.4",
+        "sherpa-onnx-win-ia32": "^1.13.4",
+        "sherpa-onnx-win-x64": "^1.13.4"
       }
     },
     "node_modules/sherpa-onnx-win-ia32": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.13.2.tgz",
-      "integrity": "sha512-PJxFuZB6VcwxscP9whLdxBMhHWZ88Ax35LeKpAZWXIvFjIviX1yPJB1+ndhXvF9Nh1L8gPgO9MUBfC1BMKqzvw==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.13.4.tgz",
+      "integrity": "sha512-/JbPjldrfNv+t+uIS3MlkuhfIf5l3FHUGkRC2oRXgjRqOaVmEyP3vLlQ7dTa4J7raG5oB8c3GoPjuSWSqT9GOQ==",
       "cpu": [
         "ia32"
       ],
@@ -19370,7 +19372,9 @@
       ]
     },
     "node_modules/sherpa-onnx-win-x64": {
-      "version": "1.12.25",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-win-x64/-/sherpa-onnx-win-x64-1.13.4.tgz",
+      "integrity": "sha512-R0PWby1VxC14TDZPq7GcfSyXSY6SAFO8Y4JwdCdqouFmeXkZ1L7Is9m98C9KxQ0dN7ZtDzhAmE/43FUs/elXRQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "qrcode": "^1.5.4",
     "radix-ui": "^1.4.3",
     "sharp": "^0.34.5",
-    "sherpa-onnx-node": "^1.12.23",
+    "sherpa-onnx-node": "^1.13.4",
     "shiki": "^4.2.0",
     "silk-wasm": "^3.7.1",
     "streamdown": "^2.5.0",


### PR DESCRIPTION
## Summary
按上轮 review 建议重新生成 lock 后单独提交。sherpa-onnx-node 1.12.x 存在 TopkIndex 堆缓冲区溢出（CWE-787/125），升级至 1.13.4。

## 漏洞出处
k2-fsa/sherpa-onnx#3628 "Fix heap-buffer-overflow in TopkIndex when topk > size"，随 1.13.3 发布，1.13.4 已包含。该问题未收录进 npm advisory 数据库，所以 `npm audit` 查不到。

## Changes
- `package.json`: `sherpa-onnx-node` ^1.12.23 → ^1.13.4
- `package-lock.json`: 由 `npm install sherpa-onnx-node@^1.13.4` 重新生成

## 说明
- 本地 `npm ci` 全量重装通过（含 electron-rebuild）
- sherpa-onnx-darwin-x64 因 npmmirror 镜像未同步 1.13.4 被 npm 跳过，该条目已从官方 registry 补齐，integrity 与 tarball 实测哈希一致
- 原生模块跨小版本，语音转文字（transcribeWorker.ts）建议实测一次

## Test plan
- [x] `npm ci` 通过
- [ ] 语音转文字功能实测
