### PR TITLE
fix: MCP server 外部客户端无法启动 + getMessages 分页失效

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "qrcode": "^1.5.4",
         "radix-ui": "^1.4.3",
         "sharp": "^0.34.5",
-        "sherpa-onnx-node": "^1.12.23",
+        "sherpa-onnx-node": "^1.13.4",
         "shiki": "^4.2.0",
         "silk-wasm": "^3.7.1",
         "streamdown": "^2.5.0",
@@ -19293,9 +19293,9 @@
       }
     },
     "node_modules/sherpa-onnx-darwin-arm64": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.13.2.tgz",
-      "integrity": "sha512-sakY1+WH/Va/vhzwlhIKXaMr0ioKsJ55w785QH+VDFyUqq1+2InbmB3BgX5gyYKeuW40R0U0IW5c7wnMArhpdw==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.13.4.tgz",
+      "integrity": "sha512-QcYKzyrTzGSx6aKCD6hUODgRS1LetqfG57Z/+i5LCyfMlrgCvDc1lRcl9cdB+TozBsLha9QwLTlI0vmDcf5JKg==",
       "cpu": [
         "arm64"
       ],
@@ -19306,9 +19306,9 @@
       ]
     },
     "node_modules/sherpa-onnx-darwin-x64": {
-      "version": "1.12.40",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.12.40.tgz",
-      "integrity": "sha512-ks+A+ecmgpy3BiVmVkSW4S7W7ce4XSjE3/ueIUtiMzuGr4Tv/+Jzae4EPTWME66CmEw2iDPSIkHci9A7ogNU+w==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.13.4.tgz",
+      "integrity": "sha512-6RGeis9K9gV/UQWOgd6Rf3iqXr2/YsBQswxHaCR4hrYkHfEIpHMfFmRWLt6nJJCOWgYW2xFxEd9yzjrafAV/Pw==",
       "cpu": [
         "x64"
       ],
@@ -19319,9 +19319,9 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-arm64": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.13.2.tgz",
-      "integrity": "sha512-IJNyd6ORcMpy1oR2ZXGNidRiPuIh5KWoOYSIOhW9UQ/BUIY43P6fq8Y3XcFj1xNjBtwke7keMW9DA7ZPYxlYoQ==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.13.4.tgz",
+      "integrity": "sha512-RMjMRqT82BgTXypNNGmLe6ZFYhc3WEvnAGl3DdkK7qB/kuXwkL3iHhV31wAecbnWPsnEpUoD+8cFovWSBzsCuw==",
       "cpu": [
         "arm64"
       ],
@@ -19332,9 +19332,9 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-x64": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.13.2.tgz",
-      "integrity": "sha512-CI2pTKgbOTOpAbm6cSwsFzJZ9qD+xcpEKPfmMCMI7KjaEePnTfky+FYxVBvllbYNk9DQznuTT0Ob9XsBhwtE/Q==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.13.4.tgz",
+      "integrity": "sha512-WZh5NCkGPFHHpYSd78iN4OnmxQeSTGyt9uZskH+im/NFHQ7elQ7B0sLzCMeRpvJxiIKvd9C6WxIJ4hYaxClfsQ==",
       "cpu": [
         "x64"
       ],
@@ -19345,21 +19345,23 @@
       ]
     },
     "node_modules/sherpa-onnx-node": {
-      "version": "1.12.25",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-node/-/sherpa-onnx-node-1.13.4.tgz",
+      "integrity": "sha512-jHWWdY9f0dbvJpdsfR/C4WNhM57+jT9Os2RyC4/qUz8HKCtj2VYFmJ9s7tue9OCFRAmdoGBkgkqD6aBZ3I8BKw==",
       "license": "Apache-2.0",
       "optionalDependencies": {
-        "sherpa-onnx-darwin-arm64": "^1.12.25",
-        "sherpa-onnx-darwin-x64": "^1.12.25",
-        "sherpa-onnx-linux-arm64": "^1.12.25",
-        "sherpa-onnx-linux-x64": "^1.12.25",
-        "sherpa-onnx-win-ia32": "^1.12.25",
-        "sherpa-onnx-win-x64": "^1.12.25"
+        "sherpa-onnx-darwin-arm64": "^1.13.4",
+        "sherpa-onnx-darwin-x64": "^1.13.4",
+        "sherpa-onnx-linux-arm64": "^1.13.4",
+        "sherpa-onnx-linux-x64": "^1.13.4",
+        "sherpa-onnx-win-ia32": "^1.13.4",
+        "sherpa-onnx-win-x64": "^1.13.4"
       }
     },
     "node_modules/sherpa-onnx-win-ia32": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmmirror.com/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.13.2.tgz",
-      "integrity": "sha512-PJxFuZB6VcwxscP9whLdxBMhHWZ88Ax35LeKpAZWXIvFjIviX1yPJB1+ndhXvF9Nh1L8gPgO9MUBfC1BMKqzvw==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.13.4.tgz",
+      "integrity": "sha512-/JbPjldrfNv+t+uIS3MlkuhfIf5l3FHUGkRC2oRXgjRqOaVmEyP3vLlQ7dTa4J7raG5oB8c3GoPjuSWSqT9GOQ==",
       "cpu": [
         "ia32"
       ],
@@ -19370,7 +19372,9 @@
       ]
     },
     "node_modules/sherpa-onnx-win-x64": {
-      "version": "1.12.25",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/sherpa-onnx-win-x64/-/sherpa-onnx-win-x64-1.13.4.tgz",
+      "integrity": "sha512-R0PWby1VxC14TDZPq7GcfSyXSY6SAFO8Y4JwdCdqouFmeXkZ1L7Is9m98C9KxQ0dN7ZtDzhAmE/43FUs/elXRQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "qrcode": "^1.5.4",
     "radix-ui": "^1.4.3",
     "sharp": "^0.34.5",
-    "sherpa-onnx-node": "^1.12.23",
+    "sherpa-onnx-node": "^1.13.4",
     "shiki": "^4.2.0",
     "silk-wasm": "^3.7.1",
     "streamdown": "^2.5.0",


### PR DESCRIPTION
## 问题

### 1. 第三方 MCP 客户端无法启动 ciphertalk-mcp

`dist-electron/mcp.js`（MCP server 入口）位于 `app.asar.unpacked`，但它 require 的依赖 `@modelcontextprotocol/sdk` 未列入 `asarUnpack`，仍被打进 `app.asar` 内。任何外部 MCP 客户端（如 Claude Desktop、Hermes）启动时都会报：

```
Error: Cannot find module '@modelcontextprotocol/sdk/server/stdio.js'
Require stack:
- .../app.asar.unpacked/dist-electron/mcp.js
```

因为 mcp.js 能解析到 unpacked 目录下的 zod/better-sqlite3，唯独 SDK 留在 asar 内无法解析。

**修复**：`build.asarUnpack` 补上 `node_modules/@modelcontextprotocol/**/*`，与已有的 zod、@ai-sdk 等保持一致。

### 2. getMessages 分页（offset/时间过滤）失效

`electron/services/chat/messageQueries.ts` 中三处 SQL 的 `OFFSET` 参数硬编码为 `0`：

```ts
params = [myRowId, minFetchPerDb, 0]   // OFFSET 恒为 0
```

传入的 `offset` 从未真正进入 SQL。`readService` 的 scanOffset 循环每次取到的都是同一批最新消息，导致 MCP `get_messages` 的 offset 分页与 startTime/endTime 过滤全部失效（翻页永远返回最新一批）。

**修复**：将 SQL 的 OFFSET 改为传入的 `offset`，JS 层相应只截前 `limit` 条（避免双重偏移），`hasMore` 判断同步修正。

## 验证

- `npm run build:mcp` 通过
- 外部 MCP 客户端（stdio）可正常启动并完成 initialize 握手
- `get_messages` offset 翻页可返回不同批次（修复前 offset=0/200/400 返回完全相同结果）

---

Fixes #339