### PR TITLE
fix: MCP server 外部客户端无法启动 + getMessages 分页失效

### DIFF
--- a/electron/services/chat/messageQueries.ts
+++ b/electron/services/chat/messageQueries.ts
@@ -84,17 +84,17 @@ export async function getMessages(state: ChatServiceState,
                  LEFT JOIN Name2Id n ON m.real_sender_id = n.rowid
                  ORDER BY m.sort_seq DESC, m.create_time DESC, m.local_id DESC
                  LIMIT ? OFFSET ?`
-          params = [myRowId, minFetchPerDb, 0]
+          params = [myRowId, minFetchPerDb, offset]
         } else if (hasName2IdTable) {
           sql = `SELECT m.*, n.user_name AS sender_username
                  FROM ${tableName} m
                  LEFT JOIN Name2Id n ON m.real_sender_id = n.rowid
                  ORDER BY m.sort_seq DESC, m.create_time DESC, m.local_id DESC
                  LIMIT ? OFFSET ?`
-          params = [minFetchPerDb, 0]
+          params = [minFetchPerDb, offset]
         } else {
           sql = `SELECT * FROM ${tableName} ORDER BY sort_seq DESC, create_time DESC, local_id DESC LIMIT ? OFFSET ?`
-          params = [minFetchPerDb, 0]
+          params = [minFetchPerDb, offset]
         }
 
         const rows = await dbAdapter.all<any>('message', dbPath, sql, params)
@@ -236,10 +236,10 @@ export async function getMessages(state: ChatServiceState,
       return true
     })
 
-    // 应用 offset 和 limit
+    // 应用 offset 和 limit（SQL 层已按 offset 取数，这里只截前 limit 条）
     // hasMore 多报安全（下一页拉空时前端会自行收口），少报会让用户永远翻不到更早的消息
-    const hasMore = allMessages.length > offset + limit || anyDbHitFetchLimit
-    const messages = allMessages.slice(offset, offset + limit)
+    const hasMore = allMessages.length > limit || anyDbHitFetchLimit
+    const messages = allMessages.slice(0, limit)
 
     // 反转使最新消息在最后（UI 显示顺序）
     messages.reverse()

--- a/package.json
+++ b/package.json
@@ -311,6 +311,7 @@
       "node_modules/zod/**/*",
       "node_modules/ai/**/*",
       "node_modules/@ai-sdk/**/*",
+      "node_modules/@modelcontextprotocol/**/*",
       "node_modules/undici/**/*",
       "node_modules/@opentelemetry/**/*",
       "node_modules/@vercel/oidc/**/*",


### PR DESCRIPTION
## 问题

### 1. 第三方 MCP 客户端无法启动 ciphertalk-mcp

`dist-electron/mcp.js`（MCP server 入口）位于 `app.asar.unpacked`，但它 require 的依赖 `@modelcontextprotocol/sdk` 未列入 `asarUnpack`，仍被打进 `app.asar` 内。任何外部 MCP 客户端（如 Claude Desktop、Hermes）启动时都会报：

```
Error: Cannot find module '@modelcontextprotocol/sdk/server/stdio.js'
Require stack:
- .../app.asar.unpacked/dist-electron/mcp.js
```

因为 mcp.js 能解析到 unpacked 目录下的 zod/better-sqlite3，唯独 SDK 留在 asar 内无法解析。

**修复**：`build.asarUnpack` 补上 `node_modules/@modelcontextprotocol/**/*`，与已有的 zod、@ai-sdk 等保持一致。

### 2. getMessages 分页（offset/时间过滤）失效

`electron/services/chat/messageQueries.ts` 中三处 SQL 的 `OFFSET` 参数硬编码为 `0`：

```ts
params = [myRowId, minFetchPerDb, 0]   // OFFSET 恒为 0
```

传入的 `offset` 从未真正进入 SQL。`readService` 的 scanOffset 循环每次取到的都是同一批最新消息，导致 MCP `get_messages` 的 offset 分页与 startTime/endTime 过滤全部失效（翻页永远返回最新一批）。

**修复**：将 SQL 的 OFFSET 改为传入的 `offset`，JS 层相应只截前 `limit` 条（避免双重偏移），`hasMore` 判断同步修正。

## 验证

- `npm run build:mcp` 通过
- 外部 MCP 客户端（stdio）可正常启动并完成 initialize 握手
- `get_messages` offset 翻页可返回不同批次（修复前 offset=0/200/400 返回完全相同结果）

---

Fixes #339